### PR TITLE
[TEMP PR] encryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,11 @@
         }
       }
     },
+    "@eluvio/crypto": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@eluvio/crypto/-/crypto-1.0.3.tgz",
+      "integrity": "sha512-TVDbhl90W85frCeofqifXMm9w98TROGSM19Wsq9HfwYWNE+hWqkA6irq+GxlcTXc7sJCe3UyhzXjQTzXYClfUw=="
+    },
     "@types/node": {
       "version": "10.11.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.3.tgz",
@@ -5798,7 +5803,6 @@
           "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
           "dev": true,
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
@@ -5807,8 +5811,7 @@
           "dependencies": {
             "bignumber.js": {
               "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
-              "dev": true
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
+    "@eluvio/crypto": "^1.0.3",
     "bs58": "^4.0.1",
     "cbor": "^4.1.1",
     "deep-equal": "^1.0.1",

--- a/test/Test.js
+++ b/test/Test.js
@@ -10,7 +10,7 @@ const Test = async () => {
     hostname: "localhost",
     port: 8008,
     useHTTPS: false,
-    ethHostname: "eth1.contentfabric.io",
+    //ethHostname: "eth1.contentfabric.io",
     ethHostname: "127.0.0.1",
     ethPort: 7545,
     ethUseHTTPS: false
@@ -19,7 +19,7 @@ const Test = async () => {
   let wallet = Client.GenerateWallet();
   let signer = wallet.AddAccount({
     accountName: "Alice",
-    privateKey: "04832aec82a6572d9a5782c4af9d7d88b0eb89116349ee484e96b97daeab5ca6"
+    privateKey: "c4c07927eb6085923d8e15277718d6afcff4b32841efe2e5a1048c79d9e363ff"
   });
 
   signer = Client.ConnectSigner({signer});


### PR DESCRIPTION
Created a PR just because it lets you filter out whitespace changes (I couldn't find it in the normal commit view) - a linter auto-format somehow ran over it. We can close this after we figure out what to do.

Anyway this is a minimal test to pull in elv-crypto through npm and use it in Test.js. @elv-kevin I'm not sure how you want to add encryption to the API or if I should take on the task.

Notes:
* The IV should be generated for each block (of size elvc.ENC_BLOCK_SIZE), and block encryption also produces a tag and block key. These need to be fed when decrypting a block. You also need to keep track of the size.
* Fetch in Node seems to only support Stream as the body (the browser gives more options). We probably want to use the streaming APIs anyway but there might be some implementation differences between web and Node.