### PR TITLE
Add new commands for manipulating ABR mezzanine offerings

### DIFF
--- a/testScripts/MezzanineStatus.js
+++ b/testScripts/MezzanineStatus.js
@@ -20,11 +20,11 @@ const argv = yargs
   })
   .demandOption(
     ["objectId"],
-    "\nUsage: PRIVATE_KEY=<private-key> node MezzanineStatus.js --objectId <mezzanine-object-id> (--finalize) (--variant \"default\")\n"
+    "\nUsage: PRIVATE_KEY=<private-key> node MezzanineStatus.js --objectId <mezzanine-object-id> (--finalize) (--offeringKey \"default\")\n"
   )
   .argv;
 
-const ClientConfiguration = (!argv["config-url"]) ? (require("../TestConfiguration.json")) : {"config-url": argv["config-url"]}
+const ClientConfiguration = (!argv["config-url"]) ? (require("../TestConfiguration.json")) : {"config-url": argv["config-url"]};
 
 
 const Status = async (objectId, offeringKey="default", finalize) => {
@@ -61,7 +61,7 @@ const Status = async (objectId, offeringKey="default", finalize) => {
       console.log(JSON.stringify(status, null, 2));
     }
   } catch(error) {
-    console.error("Error creating mezzanine:");
+    console.error("Error getting mezzanine status:");
     console.error(error.body ? JSON.stringify(error, null, 2): error);
   }
 };

--- a/testScripts/OfferingAddClear.js
+++ b/testScripts/OfferingAddClear.js
@@ -1,0 +1,49 @@
+/* eslint-disable no-console */
+
+// Adds DRM-free playout options 'dash-clear' and 'hls-clear' to an existing offering of a mezzanine
+
+const ScriptOffering = require("./parentClasses/ScriptOffering");
+
+class OfferingAddClear extends ScriptOffering {
+
+  async body() {
+    const client = await this.client();
+
+    const libraryId = this.args.libraryId;
+    const objectId = this.args.objectId;
+    const offeringKey = this.args.offeringKey;
+
+
+    let metadata = await client.ContentObjectMetadata({
+      libraryId,
+      objectId
+    });
+
+    this.validateOffering(metadata, offeringKey);
+
+    metadata.offerings[offeringKey].playout.playout_formats["hls-clear"] = {
+      drm: null,
+      protocol: {
+        type: "ProtoHls"
+      }
+    };
+
+    metadata.offerings[offeringKey].playout.playout_formats["dash-clear"] = {
+      drm: null,
+      protocol: {
+        min_buffer_length: 2,
+        type: "ProtoDash"
+      }
+    };
+
+    await this.metadataWrite(metadata);
+  }
+
+  header() {
+    return "Adding hls-clear and dash-clear playout format to mezzanine offering '" + this.args.offeringKey + "'... ";
+  }
+
+}
+
+const script = new OfferingAddClear;
+script.run();

--- a/testScripts/OfferingAddSampleAes.js
+++ b/testScripts/OfferingAddSampleAes.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-console */
+
+// Adds HLS SampleAES DRM playout option to the default offering of a mezzanine that already has HLS AES-128 playout option
+// (the new SampleAES option will use the same keys as the existing AES-128 option)
+
+// Note that this script depends on the AES-128 playout_format having the key 'hls-aes128'
+// It does not actually check the contents stored under that playout_format key
+
+const ScriptOffering = require("./parentClasses/ScriptOffering");
+
+class OfferingAddSampleAes extends ScriptOffering {
+  async body() {
+    const client = await this.client();
+    const libraryId = this.args.libraryId;
+    const objectId = this.args.objectId;
+    const offeringKey = this.args.offeringKey;
+
+    let metadata = await client.ContentObjectMetadata({
+      libraryId,
+      objectId
+    });
+
+    this.validateOffering(metadata, offeringKey);
+
+    // make sure key '/offerings/OFFERING_KEY/playout/playout_formats/hls-aes128' exists
+    if(!metadata.offerings[offeringKey].playout.playout_formats.hasOwnProperty("hls-aes128")) {
+      throw new Error("Offering '" + offeringKey + "' does not contain playout_format 'hls-aes128'");
+    }
+
+    // make sure 'hls-sample-aes' does not exist already
+    if(metadata.offerings[offeringKey].playout.playout_formats.hasOwnProperty("hls-sample-aes")) {
+      throw new Error("Offering '" + offeringKey + "' already has playout_format 'hls-sample-aes'");
+    }
+
+    console.log("Playout format 'hls-aes128' found, using as basis to create hls-sample-aes playout format...");
+
+    metadata.offerings[offeringKey].playout.playout_formats["hls-sample-aes"] = {
+      drm: {
+        enc_scheme_name: "cbcs",
+        type: "DrmSampleAes"
+      },
+      protocol: {
+        type: "ProtoHls"
+      }
+    };
+
+    // loop through streams, add 'cbcs' encryption scheme to each, copying keys from 'aes-128'
+    const streamKeys = Object.keys(metadata.offerings[offeringKey].playout.streams);
+    for(let i = 0; i < streamKeys.length; i++) {
+      const streamKey = streamKeys[i];
+      const stream = metadata.offerings[offeringKey].playout.streams[streamKey];
+      if(stream.encryption_schemes.hasOwnProperty("aes-128")) {
+        let new_enc_scheme = Object.assign({}, stream.encryption_schemes["aes-128"]);
+        new_enc_scheme.type = "EncSchemeCbcs";
+        stream.encryption_schemes["cbcs"] = new_enc_scheme;
+      } else {
+        console.log("Stream '" + streamKey + "' has no encryption_scheme 'aes-128', skipping...");
+      }
+    }
+
+    await this.metadataWrite(metdata);
+  }
+
+  header() {
+    return "Adding HLS SampleAes DRM  playout_format to mezzanine offering '" + this.args.offeringKey + "'... ";
+  }
+
+}
+
+const script = new OfferingAddSampleAes;
+script.run();

--- a/testScripts/OfferingCopy.js
+++ b/testScripts/OfferingCopy.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-console */
+
+// Copies an offering from one offering key to another
+
+const ScriptOffering = require("./parentClasses/ScriptOffering");
+
+class OfferingCopy extends ScriptOffering {
+
+  async body() {
+    const client = await this.client();
+
+    const libraryId = this.args.libraryId;
+    const objectId = this.args.objectId;
+    const offeringKey = this.args.offeringKey;
+    const targetOfferingKey = this.args.targetOfferingKey;
+
+
+    let metadata = await client.ContentObjectMetadata({
+      libraryId,
+      objectId
+    });
+
+    this.validateOffering(metadata, offeringKey);
+
+    metadata.offerings[targetOfferingKey] = metadata.offerings[offeringKey];
+
+    await this.metadataWrite(metadata);
+  }
+
+  header() {
+    return "Copying offering '" + this.args.offeringKey + "' to '" + this.args.targetOfferingKey + "'... ";
+  }
+
+  options() {
+    return super.options()
+      .option("targetOfferingKey", {
+        alias: "target-offering-key",
+        demandOption: true,
+        describe: "Offering key to copy to",
+        type: "string"
+      });
+  }
+
+}
+
+const script = new OfferingCopy;
+script.run();

--- a/testScripts/OfferingRemoveClear.js
+++ b/testScripts/OfferingRemoveClear.js
@@ -1,0 +1,49 @@
+/* eslint-disable no-console */
+
+// Removes DRM-free playout options from an existing offering of a mezzanine
+
+const ScriptOffering = require("./parentClasses/ScriptOffering");
+
+class OfferingRemoveClear extends ScriptOffering {
+
+  async body() {
+    const client = await this.client();
+
+    const libraryId = this.args.libraryId;
+    const objectId = this.args.objectId;
+    const offeringKey = this.args.offeringKey;
+
+    let clearFound = false;
+
+    let metadata = await client.ContentObjectMetadata({
+      libraryId,
+      objectId
+    });
+
+    this.validateOffering(metadata, offeringKey);
+
+    // loop through playout formats, delete ones where drm is null
+    const playoutFormatKeys = Object.keys(metadata.offerings[offeringKey].playout.playout_formats);
+    for(let i = 0; i < playoutFormatKeys.length; i++) {
+      const key = playoutFormatKeys[i];
+      if(!metadata.offerings[offeringKey].playout.playout_formats[key].drm) {
+        console.log("Found clear playout format '" + key + "', removing...");
+        delete metadata.offerings[offeringKey].playout.playout_formats[key];
+        clearFound = true;
+      }
+    }
+
+    if(clearFound) {
+      await this.metadataWrite(metadata);
+    } else {
+      console.log("No playout formats found with {drm: null}");
+    }
+  }
+
+  header() {
+    return "Removing playout formats with {drm: null} from mezzanine offering '" + this.args.offeringKey + "'... ";
+  }
+}
+
+const script = new OfferingRemoveClear;
+script.run();

--- a/testScripts/parentClasses/MetadataMixin.js
+++ b/testScripts/parentClasses/MetadataMixin.js
@@ -1,0 +1,35 @@
+/* eslint-disable no-console */
+
+// mixin to factor out common code for dealing with metadata
+
+module.exports = MetadataMixin = Base => class extends Base {
+  async metadataWrite(metadata) {
+    const client = await this.client();
+
+    const libraryId = this.args.libraryId;
+    const objectId = this.args.objectId;
+
+    const editResponse = await client.EditContentObject({
+      libraryId,
+      objectId
+    });
+
+    const writeToken = editResponse.write_token;
+
+    console.log("Writing metadata back to object...");
+    await client.ReplaceMetadata({
+      libraryId,
+      metadata,
+      objectId,
+      writeToken
+    });
+
+    console.log("Finalizing object...");
+    const finalizeResponse = await client.FinalizeContentObject({
+      libraryId,
+      objectId,
+      writeToken
+    });
+    console.log("New version hash: " + finalizeResponse.hash);
+  }
+};

--- a/testScripts/parentClasses/ScriptBase.js
+++ b/testScripts/parentClasses/ScriptBase.js
@@ -1,0 +1,111 @@
+/* eslint-disable no-console */
+
+// abstract base class for scripts
+//
+// Properties
+//
+//   args        Arguments supplied to command, either via command line or via testArgs parameter during instantiation
+//   elvClient   An elv-client-js client instance
+//
+
+const yargs = require("yargs");
+const {ElvClient} = require("../../src/ElvClient");
+
+module.exports = class ScriptBase {
+  constructor(testArgs = null) {
+    // make sure env var PRIVATE_KEY is set
+    if(!process.env.PRIVATE_KEY) {
+      throw new Error("Please set environment variable PRIVATE_KEY");
+    }
+
+    // if testArgs is present, we are running a test, use testArgs instead of yargs
+    if(testArgs) {
+      this.args = testArgs;
+    } else {
+      this.args = this.options().argv;
+    }
+
+    // if --configUrl was not passed in, try to read from ../TestConfiguration.json
+    if(!this.args.configUrl) {
+      const ClientConfiguration = require("../../TestConfiguration.json");
+      this.args.configUrl = ClientConfiguration["config-url"];
+    }
+  }
+
+  // actual work specific to individual script
+  async body() {
+    throw new Error("call to abstract base class method body()");
+  }
+
+  async client() {
+    // get client if we have not already
+    if(!this.elvClient) {
+      this.elvClient = await ElvClient.FromConfigurationUrl({
+        configUrl: this.args.configUrl,
+        region: this.args.elvGeo
+      });
+      let wallet = this.elvClient.GenerateWallet();
+      let signer = wallet.AddAccount({
+        privateKey: process.env.PRIVATE_KEY
+      });
+      await this.elvClient.SetSigner({signer});
+      this.elvClient.ToggleLogging(this.args.debug);
+    }
+    return this.elvClient;
+  }
+
+  // default footer
+  footer() {
+    return "Done.";
+  }
+
+  header() {
+    throw new Error("call to abstract base class method header()");
+  }
+
+  // Returns yargs to allow extension
+  //
+  // Subclass this method to add command line options, e.g.:
+  //
+  // class NewScript extends ScriptBase {
+  //    options() {
+  //        return this.super()
+  //          .option("newArg", {
+  //             alias: "new-arg",
+  //             demandOption: true,
+  //             describe: "My new argument",
+  //             type: "string"
+  //          }
+  //        )
+  //    }
+  // }
+  options() {
+    return yargs
+      .option("debug", {
+        describe: "Print debug logging for API calls",
+        type: "boolean"
+      })
+      .option("configUrl", {
+        alias: "config-url",
+        describe: "URL pointing to the Fabric configuration, enclosed in quotes. e.g. for Eluvio test network: --configUrl \"https://main.net955210.contentfabric.io/config\"",
+        type: "string"
+      })
+      .option("elvGeo", {
+        alias: "elv-geo",
+        choices: ["eu-west", "na-east", "na-west-north", "na-west-south"],
+        describe: "Geographic region for the fabric nodes.",
+        type: "string",
+      })
+      .version(false);
+  }
+
+  async run() {
+    console.log("\n" + this.header());
+    try {
+      await this.body();
+      console.log(this.footer()+ "\n");
+    } catch(err) {
+      console.error(err);
+    }
+  }
+};

--- a/testScripts/parentClasses/ScriptOffering.js
+++ b/testScripts/parentClasses/ScriptOffering.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-console */
+
+// parent class for scripts that work with offerings
+
+const ScriptBase = require("./ScriptBase");
+const MetadataMixin = require("./MetadataMixin");
+
+module.exports = class ScriptOffering extends MetadataMixin(ScriptBase) {
+
+  options() {
+    return super.options()
+      .option("libraryId", {
+        alias: "library-id",
+        demandOption: true,
+        describe: "Library ID (should start with 'ilib')",
+        type: "string"
+      })
+      .option("objectId", {
+        alias: "object-id",
+        demandOption: true,
+        describe: "Object ID (should start with 'iq__')",
+        type: "string"
+      })
+      .option("offeringKey", {
+        alias: "offering-key",
+        default: "default",
+        describe: "Mezzanine offering key",
+        type: "string"
+      });
+  }
+
+  validateOffering(metadata, offeringKey) {
+    // check to make sure we have offerings
+    if(!metadata.offerings) {
+      throw new Error("No offerings found in mezzanine metadata");
+    }
+
+    // check for specified offering key
+    if(!metadata.offerings.hasOwnProperty(offeringKey)) {
+      throw new Error("Offering '" + offeringKey + "' not found in mezzanine metadata");
+    }
+  }
+};


### PR DESCRIPTION
Fix usage and error messages in MezzanineStatus.js

Add new commands to testScripts/
  * OfferingAddClear.js - adds DRM-free playout formats to an offering
  * OfferingAddSampleAes.js - copies adds HLS SampleAes DRM playout format to an offering (must already have an HLS AES-128 playout format)
  * OfferingCopy.js - copies an existing offering to another offering key (overwrites any existing offering under the target key)
  * OfferingRemoveClear.js - removes playout formats that do not have DRM from an offering

Add parent and mixin classes to refactor common code for command line arguments and other frequently used operations, with an eye towards eventually refactoring the rest of the items under testScripts/