### PR TITLE
Support production masters containing files from multiple S3 buckets, + minor fixes

### DIFF
--- a/src/client/ABRPublishing.js
+++ b/src/client/ABRPublishing.js
@@ -29,11 +29,11 @@ const {
  * @param {string=} description - Description of the content
  * @param {string} contentTypeName - Name of the content type to use
  * @param {Object=} metadata - Additional metadata for the content object
- * @param {Object[]=} fileInfo - Files to upload (See UploadFiles/UploadFilesFromS3 method)
+ * @param {Array<Object>=} fileInfo - Files to upload (See UploadFiles/UploadFilesFromS3 method)
  * @param {boolean=} encrypt=false - (Local files only) - If specified, files will be encrypted
  * @param {boolean=} copy=false - (S3) If specified, files will be copied from S3
  * @param {function=} callback - Progress callback for file upload (See UploadFiles/UploadFilesFromS3 method)
- * @param {Object[]=} access=[] - Array of cloud credentials, along with path matching regex strings - Required if any files in the masters are cloud references (currently only AWS S3 is supported)
+ * @param {Array<Object>=} access=[] - Array of cloud credentials, along with path matching regex strings - Required if any files in the masters are cloud references (currently only AWS S3 is supported)
  * - If this parameter is non-empty, all items in fileInfo are assumed to be items in cloud storage
  * - Format: [
  * -           {
@@ -392,7 +392,7 @@ exports.CreateABRMezzanine = async function({
  * @param {string} libraryId - ID of the mezzanine library
  * @param {string} objectId - ID of the mezzanine object
  * @param {string=} offeringKey=default - The offering to process
- * @param {Object[]=} access - Array of S3 credentials, along with path matching regexes - Required if any files in the masters are S3 references (See CreateProductionMaster method)
+ * @param {Array<Object>=} access - Array of S3 credentials, along with path matching regexes - Required if any files in the masters are S3 references (See CreateProductionMaster method)
  * - Format: {region, bucket, accessKey, secret}
  * @param {number[]} jobIndexes - Array of LRO job indexes to start. LROs are listed in a map under metadata key /abr_mezzanine/offerings/(offeringKey)/mez_prep_specs/, and job indexes start with 0, corresponding to map keys in alphabetical order
  *

--- a/src/client/Files.js
+++ b/src/client/Files.js
@@ -61,7 +61,7 @@ exports.ListFiles = async function({libraryId, objectId, versionHash}) {
      [
        {
          path: string,
-         source: string
+         source: string // either a full path e.g. "s3://BUCKET_NAME/path..." or just the path part without "s3://BUCKET_NAME/"
        }
      ]
  *
@@ -97,6 +97,22 @@ exports.UploadFilesFromS3 = async function({
 }) {
   ValidateParameters({libraryId, objectId});
   ValidateWriteToken(writeToken);
+
+  const s3prefixRegex = /^s3:\/\/([^/]+)\//i; // for matching and extracting bucket name when full s3:// path is specified
+  // if fileInfo source paths start with s3://bucketName/, check against bucket arg passed in, and strip
+  for(let i = 0; i < fileInfo.length; i++) {
+    const fileSourcePath = fileInfo[i].source;
+    const s3prefixMatch = (s3prefixRegex.exec(fileSourcePath));
+    if(s3prefixMatch) {
+      const bucketName = s3prefixMatch[1];
+      if(bucketName !== bucket) {
+        throw Error("Full S3 file path \"" + fileSourcePath + "\" specified, but does not match provided bucket name '" + bucket + "'");
+      } else {
+        // strip prefix
+        fileInfo[i].source = fileSourcePath.replace(s3prefixRegex,"");
+      }
+    }
+  }
 
   this.Log(`Uploading files from S3: ${libraryId} ${objectId} ${writeToken}`);
 

--- a/testScripts/EditContent.js
+++ b/testScripts/EditContent.js
@@ -149,11 +149,17 @@ const EditContent = async ({
         // S3 Upload
         const {region, bucket, accessKey, secret} = access;
 
+        let fileInfo = [];
+        for(let i = 0; i < files.length; i++) {
+          const oneFilePath = files[i];
+          fileInfo.push({source: oneFilePath, path: Path.basename(oneFilePath)});
+        }
+
         await client.UploadFilesFromS3({
           libraryId,
           objectId,
           writeToken: write_token,
-          filePaths: files,
+          fileInfo,
           region,
           bucket,
           accessKey,


### PR DESCRIPTION
Additions to support creation of Production Masters containing files from multiple S3 buckets (and creation of ABR Mezzanines from those masters):

 * Allow use of full s3://BUCKET_NAME/rest/of/path strings to refer to items in S3 (affects CreateProductionMaster(),  UploadFilesFromS3(), CreateProductionMaster.js, EditContent.js). Existing convention of omitting 's3://BUCKET_NAME/' from start of path still works.

 * Allow loading S3 credential sets from a JSON file with --credentials (affects CreateProductionMaster(), StartABRMezzanineJobs(), CreateProductionMaster.js, CreateABRMezzanine.js, ProductionMasterInit.js) - if not supplied, fall back to using environment variables as a 1-element credential set.

Fix problem with EditContent.js when uploading S3 files.

Ensure correct prod_master_hash when finalizing a non-default mezzanine.

Fix a few ESLint complaints.