### PR TITLE
Various script enhancements, primarily for ABR video

### DIFF
--- a/testScripts/CreateABRMezzanine.js
+++ b/testScripts/CreateABRMezzanine.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-const { ElvClient } = require("../src/ElvClient");
+const {ElvClient} = require("../src/ElvClient");
 const readline = require("readline");
 const fs = require("fs");
 
@@ -28,7 +28,8 @@ const argv = yargs
     description: "Slug for the mezzanine (generated based on title if not specified)"
   })
   .option("ip-title-id", {
-    description: "IP title ID for the mezzanine (equivalent to slug if not specified)"
+    description: "IP title ID for the mezzanine (equivalent to slug if not specified)",
+    type: "string"
   })
   .option("title-type", {
     description: "Title type for the mezzanine",
@@ -80,7 +81,7 @@ const argv = yargs
 const ClientConfiguration = (!argv["config-url"]) ? (require("../TestConfiguration.json")) : {"config-url": argv["config-url"]};
 
 const Slugify = str =>
-  (str || "").toLowerCase().replace(/ /g, "-").replace(/[^a-z0-9-]/g,"");
+  (str || "").toLowerCase().replace(/ /g, "-").replace(/[^a-z0-9-]/g, "");
 
 const Report = response => {
   if(response.errors.length > 0) {
@@ -113,8 +114,14 @@ const Create = async ({
   elvGeo,
   credentials,
   debug,
-  wait=false
+  wait = false
 }) => {
+
+  // force ipTitleId to be a string, if present
+  if(ipTitleId) {
+    ipTitleId = ipTitleId.toString();
+  }
+
   try {
     const privateKey = process.env.PRIVATE_KEY;
     if(!privateKey) {
@@ -183,7 +190,7 @@ const Create = async ({
         throw Error("Existing mez does not have 'title' set and title argument was not provided");
       }
     } else {
-      metadata = { public: { asset_metadata: {} } };
+      metadata = {public: {asset_metadata: {}}};
     }
 
     if(abrProfile) {
@@ -275,7 +282,9 @@ const Create = async ({
     console.log("Write Token:", startResponse.lro_draft.write_token);
     console.log("Write Node:", startResponse.lro_draft.node, "\n");
 
-    if(!wait) { return; }
+    if(!wait) {
+      return;
+    }
 
     console.log("Progress:");
 
@@ -287,7 +296,9 @@ const Create = async ({
       const progress = Object.keys(status).map(id => {
         const info = status[id];
 
-        if(!info.end) { done = false; }
+        if(!info.end) {
+          done = false;
+        }
 
         if(done && info.run_state !== "finished") {
           throw Error(`LRO ${id} failed with status ${info.run_state}`);
@@ -300,7 +311,9 @@ const Create = async ({
       readline.cursorTo(process.stdout, 0, null);
       process.stdout.write(progress.join(" "));
 
-      if(done) { break; }
+      if(done) {
+        break;
+      }
 
       await new Promise(resolve => setTimeout(resolve, 10000));
     }
@@ -318,7 +331,7 @@ const Create = async ({
     console.log("\tVersion Hash:", finalizeResponse.hash, "\n");
   } catch(error) {
     console.error("Error creating mezzanine:");
-    console.error(error.body ? JSON.stringify(error, null, 2): error);
+    console.error(error.body ? JSON.stringify(error, null, 2) : error);
   }
 };
 

--- a/testScripts/CreateProductionMaster.js
+++ b/testScripts/CreateProductionMaster.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-const { ElvClient } = require("../src/ElvClient");
+const {ElvClient} = require("../src/ElvClient");
 const fs = require("fs");
 const Path = require("path");
 const mime = require("mime-types");
@@ -26,7 +26,8 @@ const argv = yargs
     description: "Slug for the mezzanine (generated based on title if not specified)"
   })
   .option("ip-title-id", {
-    description: "IP title ID for the mezzanine (equivalent to slug if not specified)"
+    description: "IP title ID for the mezzanine (equivalent to slug if not specified)",
+    type: "string"
   })
   .option("metadata", {
     description: "Metadata JSON string (or file path if prefixed with '@') to include in the object metadata",
@@ -70,9 +71,6 @@ const argv = yargs
   .argv;
 const ClientConfiguration = (!argv["config-url"]) ? (require("../TestConfiguration.json")) : {"config-url": argv["config-url"]};
 
-const Slugify = str =>
-  (str || "").toLowerCase().replace(/ /g, "-").replace(/[^a-z0-9-]/g,"");
-
 const Create = async ({
   elvGeo,
   library,
@@ -84,12 +82,18 @@ const Create = async ({
   slug,
   metadata,
   files,
-  encrypt=false,
+  encrypt = false,
   s3Reference,
   s3Copy,
   credentials,
   debug
 }) => {
+
+  // force ipTitleId to be a string, if present
+  if(ipTitleId) {
+    ipTitleId = ipTitleId.toString();
+  }
+
   try {
     const privateKey = process.env.PRIVATE_KEY;
     if(!privateKey) {
@@ -144,7 +148,7 @@ const Create = async ({
         return;
       }
     } else {
-      metadata = { public: { asset_metadata: {} } };
+      metadata = {public: {asset_metadata: {}}};
     }
 
     metadata.public.asset_metadata = {
@@ -152,9 +156,15 @@ const Create = async ({
       ...(metadata.public.asset_metadata || {})
     };
 
-    if(ipTitleId) { metadata.public.asset_metadata.ip_title_id = ipTitleId; }
-    if(displayTitle) { metadata.public.asset_metadata.displayTitle = displayTitle; }
-    if(slug) { metadata.public.asset_metadata.slug = slug; }
+    if(ipTitleId) {
+      metadata.public.asset_metadata.ip_title_id = ipTitleId;
+    }
+    if(displayTitle) {
+      metadata.public.asset_metadata.displayTitle = displayTitle;
+    }
+    if(slug) {
+      metadata.public.asset_metadata.slug = slug;
+    }
 
     name = name || title + " MASTER";
 
@@ -173,7 +183,7 @@ const Create = async ({
     }
 
     let fileInfo;
-    let fileHandles=[];
+    let fileHandles = [];
     if(access) {
       fileInfo = files.map(path => ({
         path: Path.basename(path),
@@ -273,7 +283,7 @@ const Create = async ({
     } catch(error) {
       console.error("Unrecoverable error:");
       console.log(JSON.stringify(error, null, 2));
-      console.error(error.body ? JSON.stringify(error.body, null, 2): error);
+      console.error(error.body ? JSON.stringify(error.body, null, 2) : error);
     }
   } catch(error) {
     console.error(error);

--- a/testScripts/MezzanineStatus.js
+++ b/testScripts/MezzanineStatus.js
@@ -26,6 +26,10 @@ const argv = yargs
     type: "boolean",
     description: "When finalizing, wait until publishing has finished before exiting script"
   })
+  .option("force", {
+    type: "boolean",
+    description: "When finalizing, proceed even if warning raised"
+  })
   .demandOption(
     ["objectId"],
     "\nUsage: PRIVATE_KEY=<private-key> node MezzanineStatus.js --objectId <mezzanine-object-id> (--finalize) (--wait) (--offeringKey \"default\")\n"
@@ -66,7 +70,7 @@ function etaString(seconds) {
   return result;
 }
 
-const Status = async (objectId, offeringKey="default", finalize, wait) => {
+const Status = async (objectId, offeringKey="default", finalize, wait, force) => {
   try {
     const client = await ElvClient.FromConfigurationUrl({
       configUrl: ClientConfiguration["config-url"]
@@ -117,7 +121,7 @@ const Status = async (objectId, offeringKey="default", finalize, wait) => {
     }
     console.log(JSON.stringify(status,null,2));
 
-    if(warningsAdded) {
+    if(warningsAdded && !(finalize && force)) {
       console.error("\nWarnings raised for LRO status, exiting script!\n");
       process.exitCode = 1;
       return;
@@ -159,7 +163,7 @@ const Status = async (objectId, offeringKey="default", finalize, wait) => {
   }
 };
 
-let {objectId, offeringKey, finalize, wait} = argv;
+let {objectId, offeringKey, finalize, wait, force} = argv;
 
 const privateKey = process.env.PRIVATE_KEY;
 if(!privateKey) {
@@ -168,7 +172,7 @@ if(!privateKey) {
   return;
 }
 
-Status(objectId, offeringKey, finalize, wait).then(successValue => {
+Status(objectId, offeringKey, finalize, wait, force).then(successValue => {
   // nothing
   return successValue;
 }, failureReason => {

--- a/testScripts/ObjectDelete.js
+++ b/testScripts/ObjectDelete.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+
+const ScriptBase = require("./parentClasses/ScriptBase");
+
+class ObjectDelete extends ScriptBase {
+
+  async body() {
+    const client = await this.client();
+
+    const libraryId = this.args.libraryId;
+    const objectId = this.args.objectId;
+
+    await client.DeleteContentObject({
+      libraryId,
+      objectId
+    });
+  }
+
+  header() {
+    return "Deleting object " + this.args.objectId + "... ";
+  }
+
+  options() {
+    return super.options()
+      .option("libraryId", {
+        alias: "library-id",
+        demandOption: true,
+        describe: "Library ID (should start with 'ilib')",
+        type: "string"
+      })
+      .option("objectId", {
+        alias: "object-id",
+        demandOption: true,
+        describe: "Object ID (should start with 'iq__')",
+        type: "string"
+      });
+  }
+}
+
+const script = new ObjectDelete;
+script.run();

--- a/testScripts/ObjectSetImage.js
+++ b/testScripts/ObjectSetImage.js
@@ -8,7 +8,7 @@ function getNestedObject(nestedObj, pathArr) {
     (obj && obj[key] !== "undefined") ? obj[key] : undefined, nestedObj);
 }
 
-class OfferingSetImage extends MetadataMixin(ScriptBase) {
+class ObjectSetImage extends MetadataMixin(ScriptBase) {
 
   async body() {
     const client = await this.client();
@@ -87,5 +87,5 @@ class OfferingSetImage extends MetadataMixin(ScriptBase) {
   }
 }
 
-const script = new OfferingSetImage;
+const script = new ObjectSetImage;
 script.run();

--- a/testScripts/ObjectSetImage.js
+++ b/testScripts/ObjectSetImage.js
@@ -1,0 +1,91 @@
+/* eslint-disable no-console */
+
+const ScriptBase = require("./parentClasses/ScriptBase");
+const MetadataMixin = require("./parentClasses/MetadataMixin");
+
+function getNestedObject(nestedObj, pathArr) {
+  return pathArr.reduce((obj, key) =>
+    (obj && obj[key] !== "undefined") ? obj[key] : undefined, nestedObj);
+}
+
+class OfferingSetImage extends MetadataMixin(ScriptBase) {
+
+  async body() {
+    const client = await this.client();
+
+    const metadataImageSubtree = "public/display_image";
+
+    const libraryId = this.args.libraryId;
+    const objectId = this.args.objectId;
+    const image = this.args.image;
+    if(image.charAt(0) === "/") {
+      throw new Error("--image must not start with '/'");
+    }
+
+    let filesMap = await client.ListFiles({
+      libraryId,
+      objectId
+    });
+
+    // check to make sure image exists
+    const keys =  image.split("/");
+    const fileEntry = getNestedObject(filesMap, keys);
+    if(!fileEntry) {
+      throw new Error("Image file '" + image + "' not found in object");
+    }
+
+    // modify and write metadata
+    const editResponse = await client.EditContentObject({
+      libraryId,
+      objectId
+    });
+    const writeToken = editResponse.write_token;
+
+    await client.ReplaceMetadata({
+      libraryId,
+      objectId,
+      writeToken,
+      metadataSubtree: metadataImageSubtree,
+      metadata: {
+        "/": `./files/${image}`
+      }
+    });
+
+    console.log("Finalizing object...");
+    const finalizeResponse = await client.FinalizeContentObject({
+      libraryId,
+      objectId,
+      writeToken
+    });
+    console.log("New version hash: " + finalizeResponse.hash);
+
+  }
+
+  header() {
+    return "Setting image for object " + this.args.objectId + " to '" + this.args.image + "'... ";
+  }
+
+  options() {
+    return super.options()
+      .option("libraryId", {
+        alias: "library-id",
+        demandOption: true,
+        describe: "Library ID (should start with 'ilib')",
+        type: "string"
+      })
+      .option("objectId", {
+        alias: "object-id",
+        demandOption: true,
+        describe: "Object ID (should start with 'iq__')",
+        type: "string"
+      })
+      .option("image", {
+        demandOption: true,
+        describe: "Image file path within object (do not include leading '/')",
+        type: "string"
+      });
+  }
+}
+
+const script = new OfferingSetImage;
+script.run();

--- a/testScripts/OfferingAddCaptionStream.js
+++ b/testScripts/OfferingAddCaptionStream.js
@@ -257,10 +257,4 @@ class OfferingAddCaptionStream extends ScriptOffering {
 }
 
 const script = new OfferingAddCaptionStream;
-script.run().then(successValue => {
-  // nothing
-  return successValue;
-}, failureReason => {
-  console.error(failureReason);
-  process.exitCode = 1;
-});
+script.run();

--- a/testScripts/OfferingAddCaptionStream.js
+++ b/testScripts/OfferingAddCaptionStream.js
@@ -9,8 +9,8 @@ const path = require("path");
 
 const ScriptOffering = require("./parentClasses/ScriptOffering");
 
-const RE_VTT_TIMESTAMP_LINE = /(^.*)([0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}) --> ([0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3})(.*$)/;
-const RE_VTT_TIMESTAMP_PARTS = /([0-9]{2}):([0-9]{2}):([0-9]{2}\.[0-9]{3})/;
+const RE_VTT_TIMESTAMP_LINE = /^(([0-9]{2}:)?[0-9]{2}:[0-9]{2}\.[0-9]{3}) --> (([0-9]{2}:)?[0-9]{2}:[0-9]{2}\.[0-9]{3})(.*$)/;
+const RE_VTT_TIMESTAMP_PARTS = /(([0-9]{2}):)?([0-9]{2}):([0-9]{2}\.[0-9]{3})/;
 
 function zeroPadLeft(value, width) {
   return (value + "").padStart(width, "0");
@@ -18,7 +18,7 @@ function zeroPadLeft(value, width) {
 
 function timeStampShift(timestamp, offset) {
   const match = RE_VTT_TIMESTAMP_PARTS.exec(timestamp);
-  const shiftedSeconds = parseInt(match[1],10) * 3600 + parseInt(match[2], 10) * 60 + parseFloat(match[3]) + offset;
+  const shiftedSeconds = parseInt(match[2] || 0,10) * 3600 + parseInt(match[3], 10) * 60 + parseFloat(match[4]) + offset;
   if(shiftedSeconds < 0) {
     throw new Error("timeShift resulted in negative timestamp");
   }
@@ -33,7 +33,7 @@ function timeStampShift(timestamp, offset) {
 function vttLineTimeShift(line, offset) {
   const match = RE_VTT_TIMESTAMP_LINE.exec(line);
   if(match !== null) {
-    return match[1] + timeStampShift(match[2], offset) + " --> " + timeStampShift(match[3], offset) + match[4];
+    return timeStampShift(match[1], offset) + " --> " + timeStampShift(match[3], offset) + match[5];
   } else {
     return line;
   }

--- a/testScripts/OfferingAddCaptionStream.js
+++ b/testScripts/OfferingAddCaptionStream.js
@@ -65,6 +65,7 @@ class OfferingAddCaptionStream extends ScriptOffering {
     const offeringKey = this.args.offeringKey;
     const filePath = this.args.file;
     const fileName = path.basename(filePath);
+    const isDefault = this.args.isDefault;
     const label = this.args.label;
     const language = this.args.language;
     const timeShift = this.args.timeShift;
@@ -165,6 +166,7 @@ class OfferingAddCaptionStream extends ScriptOffering {
       bit_rate: 100,
       codec_name: "none",
       codec_type: "captions",
+      default_for_media_type: isDefault,
       duration: {
         time_base: timeBase,
         ts: durationTs
@@ -240,6 +242,13 @@ class OfferingAddCaptionStream extends ScriptOffering {
         demandOption: true,
         describe: "Label to display for caption stream",
         type: "string"
+      })
+      .option("isDefault", {
+        alias: "is-default",
+        default: false,
+        demandOption: false,
+        describe: "Set as default caption stream",
+        type: "boolean"
       })
       .option("language", {
         alias: "lang",

--- a/testScripts/OfferingAddCaptionStream.js
+++ b/testScripts/OfferingAddCaptionStream.js
@@ -169,6 +169,7 @@ class OfferingAddCaptionStream extends ScriptOffering {
         time_base: timeBase,
         ts: durationTs
       },
+      label: label,
       language: language,
       optimum_seg_dur: {
         "time_base": timeBase,

--- a/testScripts/OfferingRemoveHls.js
+++ b/testScripts/OfferingRemoveHls.js
@@ -1,0 +1,49 @@
+/* eslint-disable no-console */
+
+// Removes HLS playout options from an existing offering of a mezzanine
+
+const ScriptOffering = require("./parentClasses/ScriptOffering");
+
+class OfferingRemoveHls extends ScriptOffering {
+
+  async body() {
+    const client = await this.client();
+
+    const libraryId = this.args.libraryId;
+    const objectId = this.args.objectId;
+    const offeringKey = this.args.offeringKey;
+
+    let hlsFound = false;
+
+    let metadata = await client.ContentObjectMetadata({
+      libraryId,
+      objectId
+    });
+
+    this.validateOffering(metadata, offeringKey);
+
+    // loop through playout formats, delete ones where protocol is HLS
+    const playoutFormatKeys = Object.keys(metadata.offerings[offeringKey].playout.playout_formats);
+    for(let i = 0; i < playoutFormatKeys.length; i++) {
+      const key = playoutFormatKeys[i];
+      if(metadata.offerings[offeringKey].playout.playout_formats[key].protocol.type === "ProtoHls") {
+        console.log("Found HLS playout format '" + key + "', removing...");
+        delete metadata.offerings[offeringKey].playout.playout_formats[key];
+        hlsFound = true;
+      }
+    }
+
+    if(hlsFound) {
+      await this.metadataWrite(metadata);
+    } else {
+      console.log("No playout formats found with HLS");
+    }
+  }
+
+  header() {
+    return "Removing playout formats with HLS from mezzanine offering '" + this.args.offeringKey + "'... ";
+  }
+}
+
+const script = new OfferingRemoveHls;
+script.run();

--- a/testScripts/VariantAddStream.js
+++ b/testScripts/VariantAddStream.js
@@ -1,0 +1,112 @@
+/* eslint-disable no-console */
+
+// Change source info for an existing stream in a variant
+
+
+const ScriptVariant = require("./parentClasses/ScriptVariant");
+
+class VariantAddStream extends ScriptVariant {
+
+  async body() {
+    const client = await this.client();
+
+    const libraryId = this.args.libraryId;
+    const objectId = this.args.objectId;
+
+    const streamKey = this.args.streamKey;
+    const label = this.args.label;
+    const language = this.args.language;
+    const default_for_media_type = this.args.isDefault;
+    const variantKey = this.args.variantKey;
+    const filePath = this.args.file;
+    const streamIndex = this.args.streamIndex;
+
+    // ===============================================================
+    // retrieve metadata from object and validate presence of variant
+    // ===============================================================
+    let metadata = await client.ContentObjectMetadata({
+      libraryId,
+      objectId
+    });
+    this.validateVariant(metadata, variantKey);
+    this.validateStreamSource(metadata, filePath, streamIndex);
+
+    // =======================================
+    // make sure entry for specified stream does not already exist
+    // =======================================
+
+    let variantStreams = metadata.production_master.variants[variantKey].streams;
+
+    if(variantStreams.hasOwnProperty(streamKey)) {
+      this.throwError("Stream '" + streamKey + "' is already present in variant '" + variantKey + "'");
+    }
+
+    // make our changes
+    const variantStream = {
+      default_for_media_type,
+      label,
+      language,
+      mapping_info: "",
+      sources: [
+        {
+          files_api_path: filePath,
+          stream_index: streamIndex
+        }
+      ]
+    };
+
+    // merge into object variant metadata
+    variantStreams[streamKey] = variantStream;
+
+    // write back to object
+    await this.metadataWrite(metadata);
+  }
+
+  header() {
+    return "Adding stream '" + this.args.streamKey + "' to variant '" + this.args.variantKey + "'... ";
+  }
+
+  options() {
+    return super.options()
+      .option("streamKey", {
+        alias: "stream-key",
+        demandOption: true,
+        describe: "Stream within variant to change",
+        type: "string"
+      })
+      .option("label", {
+        demandOption: true,
+        describe: "Label to display for stream",
+        type: "string"
+      })
+      .option("language", {
+        alias: "lang",
+        demandOption: true,
+        describe: "Language code for stream (some older players may use this as the label)",
+        type: "string"
+      })
+      .option("isDefault", {
+        alias: "is-default",
+        default: false,
+        demandOption: false,
+        describe: "Stream should be chosen by default",
+        type: "boolean"
+      })
+      .option("file", {
+        alias: "f",
+        demandOption: true,
+        describe: "File path within object",
+        type: "string"
+      })
+      .option("streamIndex", {
+        alias: "stream-index",
+        demandOption: true,
+        describe: "Index of stream to use from file",
+        type: "number"
+      });
+
+  }
+}
+
+const script = new VariantAddStream;
+script.run();

--- a/testScripts/VariantChangeStreamSource.js
+++ b/testScripts/VariantChangeStreamSource.js
@@ -1,0 +1,85 @@
+/* eslint-disable no-console */
+
+// Change source info for an existing stream in a variant
+
+
+const ScriptVariant = require("./parentClasses/ScriptVariant");
+
+class VariantChangeStreamSource extends ScriptVariant {
+
+  async body() {
+    const client = await this.client();
+
+    const libraryId = this.args.libraryId;
+    const objectId = this.args.objectId;
+
+    const streamKey = this.args.streamKey;
+    const variantKey = this.args.variantKey;
+    const filePath = this.args.file;
+    const streamIndex = this.args.streamIndex;
+
+    // ===============================================================
+    // retrieve metadata from object and validate presence of variant
+    // ===============================================================
+    let metadata = await client.ContentObjectMetadata({
+      libraryId,
+      objectId
+    });
+
+    this.validateVariant(metadata, variantKey);
+    this.validateStreamSource(metadata, filePath, streamIndex);
+
+    // =======================================
+    // find entry for specified stream
+    // =======================================
+
+    let variantStreams = metadata.production_master.variants[variantKey].streams;
+
+    if(!variantStreams.hasOwnProperty(streamKey)) {
+      this.throwError("Stream '" + streamKey + "' not found in variant '" + variantKey + "'");
+    }
+
+    let variantStream = variantStreams[streamKey];
+    if(variantStream.sources.length !== 1) {
+      this.throwError("Stream '" + streamKey + "' in variant '" + variantKey + "' is not single-source. Currently only variant streams with 1 source are supported.");
+    }
+
+    // make our changes
+
+    variantStream.sources[0].files_api_path = filePath;
+    variantStream.sources[0].stream_index = streamIndex;
+
+    // write back to object
+    await this.metadataWrite(metadata);
+  }
+
+  header() {
+    return "Changing source for stream '" + this.args.streamKey + "' in variant '" + this.args.variantKey + "'... ";
+  }
+
+  options() {
+    return super.options()
+      .option("streamKey", {
+        alias: "stream-key",
+        demandOption: true,
+        describe: "Stream within variant to change",
+        type: "string"
+      })
+      .option("file", {
+        alias: "f",
+        demandOption: true,
+        describe: "File path within object",
+        type: "string"
+      })
+      .option("streamIndex", {
+        alias: "stream-index",
+        demandOption: true,
+        describe: "Index of stream to use from file",
+        type: "number"
+      });
+
+  }
+}
+
+const script = new VariantChangeStreamSource;
+script.run();

--- a/testScripts/abr_profile_4k_both.json
+++ b/testScripts/abr_profile_4k_both.json
@@ -2,6 +2,15 @@
   "drm_optional": true,
   "store_clear": false,
   "ladder_specs": {
+    "{\"media_type\":\"audio\",\"channels\":1}": {
+      "rung_specs": [
+        {
+          "bit_rate": 128000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
     "{\"media_type\":\"audio\",\"channels\":2}": {
       "rung_specs": [
         {

--- a/testScripts/abr_profile_4k_clear.json
+++ b/testScripts/abr_profile_4k_clear.json
@@ -2,6 +2,15 @@
   "drm_optional": true,
   "store_clear": true,
   "ladder_specs": {
+    "{\"media_type\":\"audio\",\"channels\":1}": {
+      "rung_specs": [
+        {
+          "bit_rate": 128000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
     "{\"media_type\":\"audio\",\"channels\":2}": {
       "rung_specs": [
         {

--- a/testScripts/abr_profile_4k_drm.json
+++ b/testScripts/abr_profile_4k_drm.json
@@ -2,6 +2,15 @@
   "drm_optional": false,
   "store_clear": false,
   "ladder_specs": {
+    "{\"media_type\":\"audio\",\"channels\":1}": {
+      "rung_specs": [
+        {
+          "bit_rate": 128000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
     "{\"media_type\":\"audio\",\"channels\":2}": {
       "rung_specs": [
         {

--- a/testScripts/abr_profile_both.json
+++ b/testScripts/abr_profile_both.json
@@ -11,49 +11,418 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":17,\"aspect_ratio_width\":40}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":729,\"aspect_ratio_width\":1280}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
           "height": 1080,
           "media_type": "video",
           "pregenerate": true,
-          "width": 2538
+          "width": 1920
         },
         {
-          "bit_rate": 6000000,
+          "bit_rate": 4500000,
           "height": 720,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1692
+          "width": 1280
         },
         {
-          "bit_rate": 2640000,
+          "bit_rate": 2000000,
           "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1270
+          "width": 960
         },
         {
-          "bit_rate": 1450000,
+          "bit_rate": 1100000,
           "height": 432,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1016
+          "width": 768
         },
         {
-          "bit_rate": 1070000,
+          "bit_rate": 810000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 846
+          "width": 640
         },
         {
-          "bit_rate": 690000,
+          "bit_rate": 520000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 846
+          "width": 640
+        }
+
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":1,\"aspect_ratio_width\":2}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2160
+        },
+        {
+          "bit_rate": 5000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1440
+        },
+        {
+          "bit_rate": 2250000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1200000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 864
+        },
+        {
+          "bit_rate": 910000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 580000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":67,\"aspect_ratio_width\":120}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":539,\"aspect_ratio_width\":960}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":11,\"aspect_ratio_width\":15}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":11,\"aspect_ratio_width\":20}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":12296,\"aspect_ratio_width\":21851}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":131072,\"aspect_ratio_width\":192165}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":176}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
         }
       ]
     },
@@ -103,81 +472,81 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":1,\"aspect_ratio_width\":2}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":76}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
-          "height": 1080,
+          "height": 1920,
           "media_type": "video",
           "pregenerate": true,
-          "width": 2160
-        },
-        {
-          "bit_rate": 5000000,
-          "height": 720,
-          "media_type": "video",
-          "pregenerate": false,
-          "width": 1440
-        },
-        {
-          "bit_rate": 2250000,
-          "height": 540,
-          "media_type": "video",
-          "pregenerate": false,
           "width": 1080
         },
         {
-          "bit_rate": 1200000,
-          "height": 432,
-          "media_type": "video",
-          "pregenerate": false,
-          "width": 864
-        },
-        {
-          "bit_rate": 910000,
-          "height": 360,
+          "bit_rate": 4500000,
+          "height": 1280,
           "media_type": "video",
           "pregenerate": false,
           "width": 720
         },
         {
-          "bit_rate": 580000,
+          "bit_rate": 2000000,
+          "height": 960,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 768,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 432
+        },
+        {
+          "bit_rate": 810000,
           "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":16,\"aspect_ratio_width\":9}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1920,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1080
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 1280,
           "media_type": "video",
           "pregenerate": false,
           "width": 720
-        }
-      ]
-    },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":9,\"aspect_ratio_width\":16}": {
-      "rung_specs": [
-        {
-          "bit_rate": 9500000,
-          "height": 1080,
-          "media_type": "video",
-          "pregenerate": true,
-          "width": 1920
-        },
-        {
-          "bit_rate": 4500000,
-          "height": 720,
-          "media_type": "video",
-          "pregenerate": false,
-          "width": 1280
         },
         {
           "bit_rate": 2000000,
-          "height": 540,
+          "height": 960,
           "media_type": "video",
           "pregenerate": false,
-          "width": 960
+          "width": 540
         },
         {
           "bit_rate": 1100000,
-          "height": 432,
+          "height": 768,
           "media_type": "video",
           "pregenerate": false,
-          "width": 768
+          "width": 432
         },
         {
           "bit_rate": 810000,
@@ -195,95 +564,95 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":480,\"aspect_ratio_width\":853}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":17,\"aspect_ratio_width\":40}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
           "height": 1080,
           "media_type": "video",
           "pregenerate": true,
-          "width": 1920
+          "width": 2538
         },
         {
-          "bit_rate": 4500000,
+          "bit_rate": 6000000,
           "height": 720,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1280
+          "width": 1692
         },
         {
-          "bit_rate": 2000000,
+          "bit_rate": 2640000,
           "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 960
+          "width": 1270
         },
         {
-          "bit_rate": 1100000,
+          "bit_rate": 1450000,
           "height": 432,
           "media_type": "video",
           "pregenerate": false,
-          "width": 768
+          "width": 1016
         },
         {
-          "bit_rate": 810000,
+          "bit_rate": 1070000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 640
+          "width": 846
         },
         {
-          "bit_rate": 520000,
+          "bit_rate": 690000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 640
+          "width": 846
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":40,\"aspect_ratio_width\":71}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":173,\"aspect_ratio_width\":320}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
-          "height": 1080,
+          "height": 1036,
           "media_type": "video",
           "pregenerate": true,
           "width": 1920
         },
         {
-          "bit_rate": 4500000,
+          "bit_rate": 4700000,
           "height": 720,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1280
+          "width": 1334
         },
         {
-          "bit_rate": 2000000,
+          "bit_rate": 2080000,
           "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 960
+          "width": 1000
         },
         {
-          "bit_rate": 1100000,
+          "bit_rate": 1145000,
           "height": 432,
           "media_type": "video",
           "pregenerate": false,
-          "width": 768
+          "width": 800
         },
         {
-          "bit_rate": 810000,
+          "bit_rate": 843000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 640
+          "width": 666
         },
         {
-          "bit_rate": 520000,
+          "bit_rate": 541000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 640
+          "width": 666
         }
       ]
     },
@@ -333,6 +702,282 @@
         }
       ]
     },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":20,\"aspect_ratio_width\":27}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":240,\"aspect_ratio_width\":427}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":243,\"aspect_ratio_width\":320}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":259,\"aspect_ratio_width\":480}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":262144,\"aspect_ratio_width\":319905}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1280
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 853
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 512
+        },
+        {
+          "bit_rate": 540000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        },
+        {
+          "bit_rate": 350000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":27,\"aspect_ratio_width\":32}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1280
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 853
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 512
+        },
+        {
+          "bit_rate": 540000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        },
+        {
+          "bit_rate": 350000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        }
+      ]
+    },
     "{\"media_type\":\"video\",\"aspect_ratio_height\":27,\"aspect_ratio_width\":40}": {
       "rung_specs": [
         {
@@ -379,7 +1024,7 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":639,\"aspect_ratio_width\":889}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":297,\"aspect_ratio_width\":400}": {
       "rung_specs": [
         {
           "bit_rate": 4900000,
@@ -471,7 +1116,329 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":243,\"aspect_ratio_width\":320}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":30,\"aspect_ratio_width\":53}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":40,\"aspect_ratio_width\":71}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":429,\"aspect_ratio_width\":1024}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":466577,\"aspect_ratio_width\":912058}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":480,\"aspect_ratio_width\":853}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":486,\"aspect_ratio_width\":853}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":5,\"aspect_ratio_width\":12}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":582543,\"aspect_ratio_width\":776720}": {
       "rung_specs": [
         {
           "bit_rate": 4900000,
@@ -517,35 +1484,219 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":76}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":639,\"aspect_ratio_width\":889}": {
       "rung_specs": [
         {
-          "bit_rate": 9500000,
-          "height": 1920,
+          "bit_rate": 4900000,
+          "height": 1080,
           "media_type": "video",
           "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":65536,\"aspect_ratio_width\":87381}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":81,\"aspect_ratio_width\":128}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
           "width": 1080
         },
         {
-          "bit_rate": 4500000,
-          "height": 1280,
+          "bit_rate": 1400000,
+          "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 720
+          "width": 810
         },
         {
-          "bit_rate": 2000000,
-          "height": 960,
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
           "media_type": "video",
           "pregenerate": false,
           "width": 540
         },
         {
-          "bit_rate": 1100000,
-          "height": 768,
+          "bit_rate": 440000,
+          "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 432
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":8192,\"aspect_ratio_width\":12015}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":891,\"aspect_ratio_width\":1600}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
         },
         {
           "bit_rate": 810000,
@@ -563,35 +1714,35 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":16,\"aspect_ratio_width\":9}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":9,\"aspect_ratio_width\":16}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
-          "height": 1920,
+          "height": 1080,
           "media_type": "video",
           "pregenerate": true,
-          "width": 1080
+          "width": 1920
         },
         {
           "bit_rate": 4500000,
-          "height": 1280,
+          "height": 720,
           "media_type": "video",
           "pregenerate": false,
-          "width": 720
+          "width": 1280
         },
         {
           "bit_rate": 2000000,
-          "height": 960,
+          "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 540
+          "width": 960
         },
         {
           "bit_rate": 1100000,
-          "height": 768,
+          "height": 432,
           "media_type": "video",
           "pregenerate": false,
-          "width": 432
+          "width": 768
         },
         {
           "bit_rate": 810000,

--- a/testScripts/abr_profile_both.json
+++ b/testScripts/abr_profile_both.json
@@ -2,6 +2,15 @@
   "drm_optional": true,
   "store_clear": false,
   "ladder_specs": {
+    "{\"media_type\":\"audio\",\"channels\":1}": {
+      "rung_specs": [
+        {
+          "bit_rate": 128000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
     "{\"media_type\":\"audio\",\"channels\":2}": {
       "rung_specs": [
         {

--- a/testScripts/abr_profile_clear.json
+++ b/testScripts/abr_profile_clear.json
@@ -2,6 +2,15 @@
   "drm_optional": true,
   "store_clear": true,
   "ladder_specs": {
+    "{\"media_type\":\"audio\",\"channels\":1}": {
+      "rung_specs": [
+        {
+          "bit_rate": 128000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
     "{\"media_type\":\"audio\",\"channels\":2}": {
       "rung_specs": [
         {

--- a/testScripts/abr_profile_clear.json
+++ b/testScripts/abr_profile_clear.json
@@ -11,49 +11,418 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":17,\"aspect_ratio_width\":40}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":729,\"aspect_ratio_width\":1280}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
           "height": 1080,
           "media_type": "video",
           "pregenerate": true,
-          "width": 2538
+          "width": 1920
         },
         {
-          "bit_rate": 6000000,
+          "bit_rate": 4500000,
           "height": 720,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1692
+          "width": 1280
         },
         {
-          "bit_rate": 2640000,
+          "bit_rate": 2000000,
           "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1270
+          "width": 960
         },
         {
-          "bit_rate": 1450000,
+          "bit_rate": 1100000,
           "height": 432,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1016
+          "width": 768
         },
         {
-          "bit_rate": 1070000,
+          "bit_rate": 810000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 846
+          "width": 640
         },
         {
-          "bit_rate": 690000,
+          "bit_rate": 520000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 846
+          "width": 640
+        }
+
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":1,\"aspect_ratio_width\":2}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2160
+        },
+        {
+          "bit_rate": 5000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1440
+        },
+        {
+          "bit_rate": 2250000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1200000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 864
+        },
+        {
+          "bit_rate": 910000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 580000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":67,\"aspect_ratio_width\":120}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":539,\"aspect_ratio_width\":960}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":11,\"aspect_ratio_width\":15}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":11,\"aspect_ratio_width\":20}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":12296,\"aspect_ratio_width\":21851}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":131072,\"aspect_ratio_width\":192165}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":176}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
         }
       ]
     },
@@ -103,81 +472,81 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":1,\"aspect_ratio_width\":2}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":76}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
-          "height": 1080,
+          "height": 1920,
           "media_type": "video",
           "pregenerate": true,
-          "width": 2160
-        },
-        {
-          "bit_rate": 5000000,
-          "height": 720,
-          "media_type": "video",
-          "pregenerate": false,
-          "width": 1440
-        },
-        {
-          "bit_rate": 2250000,
-          "height": 540,
-          "media_type": "video",
-          "pregenerate": false,
           "width": 1080
         },
         {
-          "bit_rate": 1200000,
-          "height": 432,
-          "media_type": "video",
-          "pregenerate": false,
-          "width": 864
-        },
-        {
-          "bit_rate": 910000,
-          "height": 360,
+          "bit_rate": 4500000,
+          "height": 1280,
           "media_type": "video",
           "pregenerate": false,
           "width": 720
         },
         {
-          "bit_rate": 580000,
+          "bit_rate": 2000000,
+          "height": 960,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 768,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 432
+        },
+        {
+          "bit_rate": 810000,
           "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":16,\"aspect_ratio_width\":9}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1920,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1080
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 1280,
           "media_type": "video",
           "pregenerate": false,
           "width": 720
-        }
-      ]
-    },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":9,\"aspect_ratio_width\":16}": {
-      "rung_specs": [
-        {
-          "bit_rate": 9500000,
-          "height": 1080,
-          "media_type": "video",
-          "pregenerate": true,
-          "width": 1920
-        },
-        {
-          "bit_rate": 4500000,
-          "height": 720,
-          "media_type": "video",
-          "pregenerate": false,
-          "width": 1280
         },
         {
           "bit_rate": 2000000,
-          "height": 540,
+          "height": 960,
           "media_type": "video",
           "pregenerate": false,
-          "width": 960
+          "width": 540
         },
         {
           "bit_rate": 1100000,
-          "height": 432,
+          "height": 768,
           "media_type": "video",
           "pregenerate": false,
-          "width": 768
+          "width": 432
         },
         {
           "bit_rate": 810000,
@@ -195,95 +564,95 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":480,\"aspect_ratio_width\":853}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":17,\"aspect_ratio_width\":40}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
           "height": 1080,
           "media_type": "video",
           "pregenerate": true,
-          "width": 1920
+          "width": 2538
         },
         {
-          "bit_rate": 4500000,
+          "bit_rate": 6000000,
           "height": 720,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1280
+          "width": 1692
         },
         {
-          "bit_rate": 2000000,
+          "bit_rate": 2640000,
           "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 960
+          "width": 1270
         },
         {
-          "bit_rate": 1100000,
+          "bit_rate": 1450000,
           "height": 432,
           "media_type": "video",
           "pregenerate": false,
-          "width": 768
+          "width": 1016
         },
         {
-          "bit_rate": 810000,
+          "bit_rate": 1070000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 640
+          "width": 846
         },
         {
-          "bit_rate": 520000,
+          "bit_rate": 690000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 640
+          "width": 846
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":40,\"aspect_ratio_width\":71}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":173,\"aspect_ratio_width\":320}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
-          "height": 1080,
+          "height": 1036,
           "media_type": "video",
           "pregenerate": true,
           "width": 1920
         },
         {
-          "bit_rate": 4500000,
+          "bit_rate": 4700000,
           "height": 720,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1280
+          "width": 1334
         },
         {
-          "bit_rate": 2000000,
+          "bit_rate": 2080000,
           "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 960
+          "width": 1000
         },
         {
-          "bit_rate": 1100000,
+          "bit_rate": 1145000,
           "height": 432,
           "media_type": "video",
           "pregenerate": false,
-          "width": 768
+          "width": 800
         },
         {
-          "bit_rate": 810000,
+          "bit_rate": 843000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 640
+          "width": 666
         },
         {
-          "bit_rate": 520000,
+          "bit_rate": 541000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 640
+          "width": 666
         }
       ]
     },
@@ -333,6 +702,282 @@
         }
       ]
     },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":20,\"aspect_ratio_width\":27}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":240,\"aspect_ratio_width\":427}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":243,\"aspect_ratio_width\":320}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":259,\"aspect_ratio_width\":480}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":262144,\"aspect_ratio_width\":319905}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1280
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 853
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 512
+        },
+        {
+          "bit_rate": 540000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        },
+        {
+          "bit_rate": 350000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":27,\"aspect_ratio_width\":32}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1280
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 853
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 512
+        },
+        {
+          "bit_rate": 540000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        },
+        {
+          "bit_rate": 350000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        }
+      ]
+    },
     "{\"media_type\":\"video\",\"aspect_ratio_height\":27,\"aspect_ratio_width\":40}": {
       "rung_specs": [
         {
@@ -379,7 +1024,7 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":639,\"aspect_ratio_width\":889}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":297,\"aspect_ratio_width\":400}": {
       "rung_specs": [
         {
           "bit_rate": 4900000,
@@ -471,7 +1116,329 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":243,\"aspect_ratio_width\":320}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":30,\"aspect_ratio_width\":53}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":40,\"aspect_ratio_width\":71}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":429,\"aspect_ratio_width\":1024}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":466577,\"aspect_ratio_width\":912058}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":480,\"aspect_ratio_width\":853}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":486,\"aspect_ratio_width\":853}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":5,\"aspect_ratio_width\":12}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":582543,\"aspect_ratio_width\":776720}": {
       "rung_specs": [
         {
           "bit_rate": 4900000,
@@ -517,35 +1484,219 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":76}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":639,\"aspect_ratio_width\":889}": {
       "rung_specs": [
         {
-          "bit_rate": 9500000,
-          "height": 1920,
+          "bit_rate": 4900000,
+          "height": 1080,
           "media_type": "video",
           "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":65536,\"aspect_ratio_width\":87381}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":81,\"aspect_ratio_width\":128}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
           "width": 1080
         },
         {
-          "bit_rate": 4500000,
-          "height": 1280,
+          "bit_rate": 1400000,
+          "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 720
+          "width": 810
         },
         {
-          "bit_rate": 2000000,
-          "height": 960,
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
           "media_type": "video",
           "pregenerate": false,
           "width": 540
         },
         {
-          "bit_rate": 1100000,
-          "height": 768,
+          "bit_rate": 440000,
+          "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 432
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":8192,\"aspect_ratio_width\":12015}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":891,\"aspect_ratio_width\":1600}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
         },
         {
           "bit_rate": 810000,
@@ -563,35 +1714,35 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":16,\"aspect_ratio_width\":9}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":9,\"aspect_ratio_width\":16}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
-          "height": 1920,
+          "height": 1080,
           "media_type": "video",
           "pregenerate": true,
-          "width": 1080
+          "width": 1920
         },
         {
           "bit_rate": 4500000,
-          "height": 1280,
+          "height": 720,
           "media_type": "video",
           "pregenerate": false,
-          "width": 720
+          "width": 1280
         },
         {
           "bit_rate": 2000000,
-          "height": 960,
+          "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 540
+          "width": 960
         },
         {
           "bit_rate": 1100000,
-          "height": 768,
+          "height": 432,
           "media_type": "video",
           "pregenerate": false,
-          "width": 432
+          "width": 768
         },
         {
           "bit_rate": 810000,

--- a/testScripts/abr_profile_drm.json
+++ b/testScripts/abr_profile_drm.json
@@ -11,49 +11,418 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":17,\"aspect_ratio_width\":40}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":729,\"aspect_ratio_width\":1280}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
           "height": 1080,
           "media_type": "video",
           "pregenerate": true,
-          "width": 2538
+          "width": 1920
         },
         {
-          "bit_rate": 6000000,
+          "bit_rate": 4500000,
           "height": 720,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1692
+          "width": 1280
         },
         {
-          "bit_rate": 2640000,
+          "bit_rate": 2000000,
           "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1270
+          "width": 960
         },
         {
-          "bit_rate": 1450000,
+          "bit_rate": 1100000,
           "height": 432,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1016
+          "width": 768
         },
         {
-          "bit_rate": 1070000,
+          "bit_rate": 810000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 846
+          "width": 640
         },
         {
-          "bit_rate": 690000,
+          "bit_rate": 520000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 846
+          "width": 640
+        }
+
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":1,\"aspect_ratio_width\":2}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2160
+        },
+        {
+          "bit_rate": 5000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1440
+        },
+        {
+          "bit_rate": 2250000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1200000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 864
+        },
+        {
+          "bit_rate": 910000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 580000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":67,\"aspect_ratio_width\":120}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":539,\"aspect_ratio_width\":960}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":11,\"aspect_ratio_width\":15}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":11,\"aspect_ratio_width\":20}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":12296,\"aspect_ratio_width\":21851}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":131072,\"aspect_ratio_width\":192165}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":176}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
         }
       ]
     },
@@ -103,81 +472,81 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":1,\"aspect_ratio_width\":2}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":76}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
-          "height": 1080,
+          "height": 1920,
           "media_type": "video",
           "pregenerate": true,
-          "width": 2160
-        },
-        {
-          "bit_rate": 5000000,
-          "height": 720,
-          "media_type": "video",
-          "pregenerate": false,
-          "width": 1440
-        },
-        {
-          "bit_rate": 2250000,
-          "height": 540,
-          "media_type": "video",
-          "pregenerate": false,
           "width": 1080
         },
         {
-          "bit_rate": 1200000,
-          "height": 432,
-          "media_type": "video",
-          "pregenerate": false,
-          "width": 864
-        },
-        {
-          "bit_rate": 910000,
-          "height": 360,
+          "bit_rate": 4500000,
+          "height": 1280,
           "media_type": "video",
           "pregenerate": false,
           "width": 720
         },
         {
-          "bit_rate": 580000,
+          "bit_rate": 2000000,
+          "height": 960,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 768,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 432
+        },
+        {
+          "bit_rate": 810000,
           "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":16,\"aspect_ratio_width\":9}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1920,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1080
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 1280,
           "media_type": "video",
           "pregenerate": false,
           "width": 720
-        }
-      ]
-    },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":9,\"aspect_ratio_width\":16}": {
-      "rung_specs": [
-        {
-          "bit_rate": 9500000,
-          "height": 1080,
-          "media_type": "video",
-          "pregenerate": true,
-          "width": 1920
-        },
-        {
-          "bit_rate": 4500000,
-          "height": 720,
-          "media_type": "video",
-          "pregenerate": false,
-          "width": 1280
         },
         {
           "bit_rate": 2000000,
-          "height": 540,
+          "height": 960,
           "media_type": "video",
           "pregenerate": false,
-          "width": 960
+          "width": 540
         },
         {
           "bit_rate": 1100000,
-          "height": 432,
+          "height": 768,
           "media_type": "video",
           "pregenerate": false,
-          "width": 768
+          "width": 432
         },
         {
           "bit_rate": 810000,
@@ -195,95 +564,95 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":480,\"aspect_ratio_width\":853}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":17,\"aspect_ratio_width\":40}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
           "height": 1080,
           "media_type": "video",
           "pregenerate": true,
-          "width": 1920
+          "width": 2538
         },
         {
-          "bit_rate": 4500000,
+          "bit_rate": 6000000,
           "height": 720,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1280
+          "width": 1692
         },
         {
-          "bit_rate": 2000000,
+          "bit_rate": 2640000,
           "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 960
+          "width": 1270
         },
         {
-          "bit_rate": 1100000,
+          "bit_rate": 1450000,
           "height": 432,
           "media_type": "video",
           "pregenerate": false,
-          "width": 768
+          "width": 1016
         },
         {
-          "bit_rate": 810000,
+          "bit_rate": 1070000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 640
+          "width": 846
         },
         {
-          "bit_rate": 520000,
+          "bit_rate": 690000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 640
+          "width": 846
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":40,\"aspect_ratio_width\":71}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":173,\"aspect_ratio_width\":320}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
-          "height": 1080,
+          "height": 1036,
           "media_type": "video",
           "pregenerate": true,
           "width": 1920
         },
         {
-          "bit_rate": 4500000,
+          "bit_rate": 4700000,
           "height": 720,
           "media_type": "video",
           "pregenerate": false,
-          "width": 1280
+          "width": 1334
         },
         {
-          "bit_rate": 2000000,
+          "bit_rate": 2080000,
           "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 960
+          "width": 1000
         },
         {
-          "bit_rate": 1100000,
+          "bit_rate": 1145000,
           "height": 432,
           "media_type": "video",
           "pregenerate": false,
-          "width": 768
+          "width": 800
         },
         {
-          "bit_rate": 810000,
+          "bit_rate": 843000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 640
+          "width": 666
         },
         {
-          "bit_rate": 520000,
+          "bit_rate": 541000,
           "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 640
+          "width": 666
         }
       ]
     },
@@ -333,6 +702,282 @@
         }
       ]
     },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":20,\"aspect_ratio_width\":27}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":240,\"aspect_ratio_width\":427}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":243,\"aspect_ratio_width\":320}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":259,\"aspect_ratio_width\":480}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":262144,\"aspect_ratio_width\":319905}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1280
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 853
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 512
+        },
+        {
+          "bit_rate": 540000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        },
+        {
+          "bit_rate": 350000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":27,\"aspect_ratio_width\":32}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1280
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 853
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 512
+        },
+        {
+          "bit_rate": 540000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        },
+        {
+          "bit_rate": 350000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        }
+      ]
+    },
     "{\"media_type\":\"video\",\"aspect_ratio_height\":27,\"aspect_ratio_width\":40}": {
       "rung_specs": [
         {
@@ -379,7 +1024,7 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":639,\"aspect_ratio_width\":889}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":297,\"aspect_ratio_width\":400}": {
       "rung_specs": [
         {
           "bit_rate": 4900000,
@@ -471,7 +1116,329 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":243,\"aspect_ratio_width\":320}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":30,\"aspect_ratio_width\":53}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":40,\"aspect_ratio_width\":71}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":429,\"aspect_ratio_width\":1024}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":466577,\"aspect_ratio_width\":912058}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":480,\"aspect_ratio_width\":853}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":486,\"aspect_ratio_width\":853}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":5,\"aspect_ratio_width\":12}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":582543,\"aspect_ratio_width\":776720}": {
       "rung_specs": [
         {
           "bit_rate": 4900000,
@@ -517,35 +1484,219 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":76}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":639,\"aspect_ratio_width\":889}": {
       "rung_specs": [
         {
-          "bit_rate": 9500000,
-          "height": 1920,
+          "bit_rate": 4900000,
+          "height": 1080,
           "media_type": "video",
           "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":65536,\"aspect_ratio_width\":87381}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":81,\"aspect_ratio_width\":128}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
           "width": 1080
         },
         {
-          "bit_rate": 4500000,
-          "height": 1280,
+          "bit_rate": 1400000,
+          "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 720
+          "width": 810
         },
         {
-          "bit_rate": 2000000,
-          "height": 960,
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
           "media_type": "video",
           "pregenerate": false,
           "width": 540
         },
         {
-          "bit_rate": 1100000,
-          "height": 768,
+          "bit_rate": 440000,
+          "height": 360,
           "media_type": "video",
           "pregenerate": false,
-          "width": 432
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":8192,\"aspect_ratio_width\":12015}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":891,\"aspect_ratio_width\":1600}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
         },
         {
           "bit_rate": 810000,
@@ -563,35 +1714,35 @@
         }
       ]
     },
-    "{\"media_type\":\"video\",\"aspect_ratio_height\":16,\"aspect_ratio_width\":9}": {
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":9,\"aspect_ratio_width\":16}": {
       "rung_specs": [
         {
           "bit_rate": 9500000,
-          "height": 1920,
+          "height": 1080,
           "media_type": "video",
           "pregenerate": true,
-          "width": 1080
+          "width": 1920
         },
         {
           "bit_rate": 4500000,
-          "height": 1280,
+          "height": 720,
           "media_type": "video",
           "pregenerate": false,
-          "width": 720
+          "width": 1280
         },
         {
           "bit_rate": 2000000,
-          "height": 960,
+          "height": 540,
           "media_type": "video",
           "pregenerate": false,
-          "width": 540
+          "width": 960
         },
         {
           "bit_rate": 1100000,
-          "height": 768,
+          "height": 432,
           "media_type": "video",
           "pregenerate": false,
-          "width": 432
+          "width": 768
         },
         {
           "bit_rate": 810000,

--- a/testScripts/abr_profile_drm.json
+++ b/testScripts/abr_profile_drm.json
@@ -2,6 +2,15 @@
   "drm_optional": false,
   "store_clear": false,
   "ladder_specs": {
+    "{\"media_type\":\"audio\",\"channels\":1}": {
+      "rung_specs": [
+        {
+          "bit_rate": 128000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
     "{\"media_type\":\"audio\",\"channels\":2}": {
       "rung_specs": [
         {

--- a/testScripts/parentClasses/ScriptBase.js
+++ b/testScripts/parentClasses/ScriptBase.js
@@ -101,17 +101,18 @@ module.exports = class ScriptBase {
         describe: "Geographic region for the fabric nodes.",
         type: "string",
       })
-      .version(false);
+      .strict().version(false);
   }
 
-  async run() {
+  run() {
     console.log("\n" + this.header());
-    try {
-      await this.body();
+    this.body().then(successValue => {
       console.log(this.footer()+ "\n");
-    } catch(err) {
-      console.error(err);
-    }
+      return successValue;
+    }, failureReason => {
+      console.error(failureReason);
+      process.exitCode = 1;
+    });
   }
 
   // validate that a number is an integer

--- a/testScripts/parentClasses/ScriptVariant.js
+++ b/testScripts/parentClasses/ScriptVariant.js
@@ -1,0 +1,70 @@
+/* eslint-disable no-console */
+
+// parent class for scripts that work with variants
+
+const ScriptBase = require("./ScriptBase");
+const MetadataMixin = require("./MetadataMixin");
+
+module.exports = class ScriptVariant extends MetadataMixin(ScriptBase) {
+
+  options() {
+    return super.options()
+      .option("libraryId", {
+        alias: "library-id",
+        demandOption: true,
+        describe: "Library ID (should start with 'ilib')",
+        type: "string"
+      })
+      .option("objectId", {
+        alias: "object-id",
+        demandOption: true,
+        describe: "Object ID (should start with 'iq__')",
+        type: "string"
+      })
+      .option("variantKey", {
+        alias: "variant-key",
+        default: "default",
+        describe: "Production Master variant key",
+        type: "string"
+      });
+  }
+
+  validateVariant(metadata, variantKey) {
+    // check to make sure we have production_master
+    if(!metadata.production_master) {
+      this.throwError("Key '/production_master' not found in object metadata");
+    }
+
+    // check to make sure we have variants
+    if(!metadata.production_master.variants) {
+      this.throwError("Key '/production_master/variants' not found in object metadata");
+    }
+
+    // check for specified variant key
+    if(!metadata.production_master.variants.hasOwnProperty(variantKey)) {
+      this.throwError("Variant '" + variantKey + "' not found in production master metadata");
+    }
+  }
+
+  validateStreamSource(metadata, filePath, streamIndex) {
+    const sources = metadata.production_master.sources;
+    if(!sources.hasOwnProperty(filePath)) {
+      const sourceList = Object.keys(sources).join("\n  ");
+      this.throwError("'" + filePath + "' not found in Production Master source list. Make sure file path is correct. If you have recently added a new file to the master, try running ProductionMasterInit.js first.\n\nSources found in master:\n\n  " + sourceList);
+    }
+
+    const sourceStreams = metadata.production_master.sources[filePath].streams;
+    if(streamIndex < 0 || streamIndex >= sourceStreams.length) {
+      this.throwError("streamIndex must be between 0 and " + (sourceStreams.length - 1) + " for file '" + filePath + "'");
+    }
+
+    const sourceStream = metadata.production_master.sources[filePath].streams[streamIndex];
+    if(sourceStream.type !== "StreamAudio" && sourceStream.type !== "StreamVideo") {
+      this.throwError("streamIndex " + streamIndex + " in file '" + filePath + "' is of type '" + sourceStream.type + "', currently only StreamAudio and StreamVideo are supported");
+    }
+
+    if(sourceStream.type === "StreamAudio" && sourceStream.channels !== 2) {
+      this.throwError("streamIndex " + streamIndex + " in file '" + filePath + "' is audio but has " + sourceStream.channels + " channel(s), currently only audio streams with 2 channels are supported");
+    }
+  }
+};

--- a/testScripts/parentClasses/ScriptVariant.js
+++ b/testScripts/parentClasses/ScriptVariant.js
@@ -63,8 +63,8 @@ module.exports = class ScriptVariant extends MetadataMixin(ScriptBase) {
       this.throwError("streamIndex " + streamIndex + " in file '" + filePath + "' is of type '" + sourceStream.type + "', currently only StreamAudio and StreamVideo are supported");
     }
 
-    if(sourceStream.type === "StreamAudio" && sourceStream.channels !== 2) {
-      this.throwError("streamIndex " + streamIndex + " in file '" + filePath + "' is audio but has " + sourceStream.channels + " channel(s), currently only audio streams with 2 channels are supported");
-    }
+    // if(sourceStream.type === "StreamAudio" && sourceStream.channels !== 2) {
+    //   this.throwError("streamIndex " + streamIndex + " in file '" + filePath + "' is audio but has " + sourceStream.channels + " channel(s), currently only audio streams with 2 channels are supported");
+    // }
   }
 };


### PR DESCRIPTION
* Add new entries to ABR profiles (new aspect ratios encountered in customer files, entry for mono audio)
* Ensure that ip-title-id is JSON encoded as a string even when it looks like a number to javascript
* Add --force option to MezzanineStatus.js to allow finalizing even if LRO info looks incorrect (i.e. status stopped updating, or progress percentage not = 100%)
* Add --isDefault arg to OfferingAddCaptionStream.js
* Fix handling of VTT caption file timestamps that don't contain digits for hour
* Add new utilities in /testScripts for workflow automation
  * ObjectDelete.js
  * ObjectSetImage.js (sets thumbnail to existing file in object)
  * OfferingRemoveHls.js (removes any HLS playout formats from offering)
  * VariantAddStream.js (includes support for mixing 2 mono streams into 1 stereo stream)
  * VariantChangeStreamSource.js

