### PR TITLE
Auto-retry contract method call on nonce expired error

### DIFF
--- a/src/EthClient.js
+++ b/src/EthClient.js
@@ -285,6 +285,8 @@ class EthClient {
             const latestBlock = await this.MakeProviderCall({methodName: "getBlock", args: ["latest"]});
             overrides.gasLimit = latestBlock.gasLimit;
             overrides.gasPrice = overrides.gasPrice ? overrides.gasPrice * 1.50 : 8000000000;
+          } else if(error.code === "NONCE_EXPIRED" && error.reason === "nonce has already been used") {
+            this.Log(`Retrying method call ${methodName}`);
           } else if(!(error.message || error).includes("invalid response")) {
             this.Log(typeof error === "object" ? JSON.stringify(error, null, 2) : error, true);
             throw error;


### PR DESCRIPTION
Automatically retry contract method call when "nonce has already been used" error is returned.


Logger shows method call, followed by a retry and then a successful transaction receipt.

Relates to https://github.com/eluv-io/elv-fabric-browser/issues/17