### PR TITLE
ABRPublishing.js - Change metadata merge behavior for CreateABRMezzanine

### DIFF
--- a/src/client/ABRPublishing.js
+++ b/src/client/ABRPublishing.js
@@ -6,6 +6,7 @@
  * @module ElvClient/ABRPublishing
  */
 
+const R = require("ramda");
 const UrlJoin = require("url-join");
 const HttpClient = require("../HttpClient");
 
@@ -355,8 +356,6 @@ exports.CreateABRMezzanine = async function({
     ...metadata.public.asset_metadata
   };
 
-  metadata.elv_created_at = new Date().getTime();
-
   if(name || !existingMez) {
     metadata.name = name || `${masterName} Mezzanine`;
     metadata.public.name = name || `${masterName} Mezzanine`;
@@ -367,7 +366,23 @@ exports.CreateABRMezzanine = async function({
     metadata.public.description = description || "";
   }
 
-  await this.MergeMetadata({
+  // retrieve existing metadata to merge with updated metadata
+  const existingMetadata = await this.ContentObjectMetadata({
+    libraryId,
+    objectId: id,
+    writeToken: write_token,
+  });
+  // newer metadata values replace existing metadata, unless both new and old values are objects,
+  // in which case their keys are merged recursively
+  metadata = R.mergeDeepRight(existingMetadata, metadata);
+
+  if(!existingMez) {
+    // set creation date
+    metadata.elv_created_at = new Date().getTime();
+  }
+
+  // write metadata to mezzanine object
+  await this.ReplaceMetadata({
     libraryId,
     objectId: id,
     writeToken: write_token,

--- a/utilities/MezzanineCreate.js
+++ b/utilities/MezzanineCreate.js
@@ -126,7 +126,7 @@ class MezzanineCreate extends Utility {
 
     if(!existingPublicMetadata.asset_metadata) existingPublicMetadata.asset_metadata = {};
 
-    const mergedExistingAndArgMetadata = R.mergeRight(
+    const mergedExistingAndArgMetadata = R.mergeDeepRight(
       {public: existingPublicMetadata},
       metadataFromArg
     );


### PR DESCRIPTION
Do not concatenate lists when the same key is present in old metadata and new "to-merge" metadata (and both values are lists), instead replace old value with new.

(use Ramda's DeepMergeRight - https://ramdajs.com/docs/#mergeDeepRight )