### PR TITLE
Better error messaging for content creation with no permission

### DIFF
--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -567,6 +567,17 @@ exports.CreateContentObject = async function({libraryId, objectId, options={}}) 
   }
 
   if(!objectId) {
+    const currentAccountAddress = await this.CurrentAccountAddress();
+    const canContribute = await this.CallContractMethod({
+      contractAddress: this.utils.HashToAddress(libraryId),
+      methodName: "canContribute",
+      methodArgs: [currentAccountAddress]
+    });
+
+    if(!canContribute) {
+      throw Error(`Current user does not have permission to create content in library ${libraryId}`);
+    }
+
     this.Log("Deploying contract...");
     const { contractAddress } = await this.authClient.CreateContentObject({libraryId, typeId});
 


### PR DESCRIPTION
Create clearer error messaging for content creation when the current account has no contribute permission.
Check for permission before attempting to call contract method.

Relates to #130 