### PR TITLE
Add ValidAddress, ValidHash methods and validate tenant hash

### DIFF
--- a/src/UserProfileClient.js
+++ b/src/UserProfileClient.js
@@ -438,14 +438,19 @@ await client.userProfileClient.UserMetadata()
    * Note: This method is not accessible to applications. Eluvio core will drop the request.
    *
    * @namedParams
-   * @param level
+   * @param {string} id - The tenant ID in hash format
+   * @param {string} address - The group address to use in the hash if id is not provided
    */
   async SetTenantId({id, address}) {
-    if(id && !id.startsWith("iten")) {
+    if(id && (!id.startsWith("iten") || !Utils.ValidHash(id))) {
       throw Error(`Invalid tenant ID: ${id}`);
     }
 
     if(address) {
+      if(!Utils.ValidAddress(address)) {
+        throw Error(`Invalid address: ${address}`);
+      }
+
       id = `iten${Utils.AddressToHash(address)}`;
     }
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -6,7 +6,8 @@ const VarInt = require("varint");
 const URI = require("urijs");
 
 const {
-  keccak256
+  keccak256,
+  getAddress
 } = require("ethers").utils;
 
 /**
@@ -243,6 +244,34 @@ const Utils = {
     }
 
     return (Utils.HashToAddress(firstHash) === Utils.HashToAddress(secondHash));
+  },
+
+  /**
+   * Determine whether the address is valid
+   *
+   * @param {string} address - Address to validate
+   *
+   * @returns {boolean} - Whether or not the address is valid
+   */
+  ValidAddress: (address) => {
+    try {
+      getAddress(address);
+      return true;
+    } catch(error) {
+      this.Log(error);
+      return false;
+    }
+  },
+
+  /**
+   * Determine whether the hash is valid
+   *
+   * @param {string} hash - Hash to validate
+   *
+   * @returns {boolean} - Whether or not the hash is valid
+   */
+  ValidHash: (hash) => {
+    return Utils.ValidAddress(Utils.HashToAddress(hash));
   },
 
   /**

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -271,6 +271,10 @@ exports.CreateContentLibrary = async function({
   }
 
   if(tenantId) {
+    if(!this.utils.ValidHash(tenantId)) {
+      throw Error(`Invalid tenant ID: ${tenantId}`);
+    }
+
     await this.CallContractMethod({
       contractAddress,
       methodName: "putMeta",


### PR DESCRIPTION
This PR addresses three items:
- Add ValidAddress for verifying that an address is the correct format. This function uses Ethers.utils.getAddress.
- Add ValidHash for verifying that a hash is the correct format.
- Validate tenant hash when creating a library and setting the tenant ID.

Validation errors in the fabric browser
![Screen Shot 2022-03-07 at 3 32 43 PM](https://user-images.githubusercontent.com/91760982/157138404-fdd6a75d-c88f-4618-b5ea-4ec9d9377ded.png)
![Screen Shot 2022-03-07 at 3 45 19 PM](https://user-images.githubusercontent.com/91760982/157138684-28ce3cd6-ce9f-444e-8c75-3fedf7925cee.png)

