### PR TITLE
Use existing link when creating auth token

### DIFF
--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -1375,8 +1375,7 @@ exports.CreateLinks = async function({
         });
 
         if(linkMetadata) {
-          link["/"] = linkMetadata["/"];
-          link["."] = linkMetadata["."];
+          link = linkMetadata;
         }
 
         if(!link["."]) link["."] = {};


### PR DESCRIPTION
Use existing link metadata if it exists so other data doesn't get removed.