### PR TITLE
Export GenerateSignedLinkToken, do not set permission in CopyContentObject

### DIFF
--- a/src/AuthorizationClient.js
+++ b/src/AuthorizationClient.js
@@ -3,8 +3,6 @@ const Ethers = require("ethers");
 const Utils = require("./Utils");
 const UrlJoin = require("url-join");
 const {LogMessage} = require("./LogMessage");
-const {ValidateObject} = require("./Validation");
-const Pako = require("pako");
 
 /*
 // -- Contract javascript files built using build/BuildContracts.js
@@ -240,47 +238,6 @@ class AuthorizationClient {
     const multiSig = Utils.FormatSignature(signature);
 
     return `${token}.${Utils.B64(multiSig)}`;
-  }
-
-  async GenerateSignedLinkToken({containerId, versionHash, link}) {
-    ValidateObject(containerId);
-    const canEdit = await this.client.CallContractMethod({
-      contractAddress: Utils.HashToAddress(containerId),
-      methodName: "canEdit"
-    });
-
-    const { objectId } = Utils.DecodeVersionHash(versionHash);
-
-    if(!canEdit) {
-      throw Error(`Current user does not have permission to edit content object ${objectId}`);
-    }
-
-    const signerAddress = this.client.CurrentAccountAddress();
-
-    let token = {
-      adr: Utils.B64(signerAddress.replace("0x", ""), "hex"),
-      spc: await this.client.ContentSpaceId(),
-      lib: await this.client.ContentObjectLibraryId({objectId}),
-      qid: objectId,
-      sub: Utils.FormatAddress(signerAddress),
-      gra: "read",
-      iat: Date.now(),
-      exp: Date.now() + 3600000,
-      ctx: {
-        elv: {
-          lnk: link,
-          src: containerId
-        }
-      }
-    };
-
-    const compressedToken = Pako.deflateRaw(Buffer.from(JSON.stringify(token), "utf-8"));
-    const signature = await this.Sign(Ethers.utils.keccak256(compressedToken));
-
-    return `aslsjc${Utils.B58(Buffer.concat([
-      Buffer.from(signature.replace(/^0x/, ""), "hex"),
-      Buffer.from(compressedToken)
-    ]))}`;
   }
 
   async MakeAccessRequest({

--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -18,6 +18,8 @@ const {
 } = require("../Validation");
 
 const MergeWith = require("lodash/mergeWith");
+const Pako = require("pako");
+const Ethers = require("ethers");
 
 
 // Note: Keep these ordered by most-restrictive to least-restrictive
@@ -2617,6 +2619,63 @@ exports.AccessRequest = async function({libraryId, objectId, versionHash, args=[
     skipCache: true,
     noCache
   });
+};
+/**
+ * Generate a signed link token.
+ *
+ * @methodGroup Access Requests
+ * @namedParams
+ * @param {string=} containerId - ID of the container object
+ * @param {string=} versionHash - Version hash of the object
+ * @param {string=} link - Path
+ * @param {string=} duration - How long the link should last in milliseconds
+ *
+ * @return {Promise<string>} - The state channel token
+ */
+exports.GenerateSignedLinkToken = async function({
+  containerId,
+  versionHash,
+  link,
+  duration
+}) {
+  ValidateObject(containerId);
+  const canEdit = await this.CallContractMethod({
+    contractAddress: this.utils.HashToAddress(containerId),
+    methodName: "canEdit"
+  });
+
+  const { objectId } = this.utils.DecodeVersionHash(versionHash);
+
+  if(!canEdit) {
+    throw Error(`Current user does not have permission to edit content object ${objectId}`);
+  }
+
+  const signerAddress = this.CurrentAccountAddress();
+
+  let token = {
+    adr: this.utils.B64(signerAddress.replace("0x", ""), "hex"),
+    spc: await this.ContentSpaceId(),
+    lib: await this.ContentObjectLibraryId({objectId}),
+    qid: objectId,
+    sub: `iusr${this.utils.AddressToHash(signerAddress)}`,
+    gra: "read",
+    iat: Date.now(),
+    exp: duration ? (Date.now() + duration) : "",
+    ctx: {
+      elv: {
+        lnk: link,
+        src: containerId
+      }
+    }
+  };
+
+  const compressedToken = Pako.deflateRaw(Buffer.from(JSON.stringify(token), "utf-8"));
+  const signature = await this.authClient.Sign(Ethers.utils.keccak256(compressedToken));
+
+  return `aslsjc${this.utils.B58(Buffer.concat([
+    Buffer.from(signature.replace(/^0x/, ""), "hex"),
+    Buffer.from(compressedToken)
+  ]))}`;
 };
 
 /**

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -670,16 +670,18 @@ exports.CopyContentObject = async function({libraryId, originalVersionHash, opti
   await Promise.all(
     Object.keys(metadata)
       .filter(key => key.startsWith("eluv.caps.ikms"))
-      .map(async kmsCapKey => await this.DeleteMetadata({
-        libraryId,
-        objectId,
-        writeToken,
-        metadataSubtree: kmsCapKey
-      }))
+      .map(async kmsCapKey =>
+        await this.DeleteMetadata({
+          libraryId,
+          objectId,
+          writeToken,
+          metadataSubtree: kmsCapKey
+        })
+      )
   );
 
   if(permission !== "owner") {
-    await this.SetPermission({objectId, permission, writeToken});
+    await this.CreateEncryptionConk({libraryId, objectId, writeToken, createKMSConk: true});
   }
 
   return await this.FinalizeContentObject({libraryId, objectId, writeToken});
@@ -1381,7 +1383,7 @@ exports.CreateLinks = async function({
         if(!link["."]) link["."] = {};
 
         if(!linkMetadata["."]["authorization"]) {
-          link["."]["authorization"] = await this.authClient.GenerateSignedLinkToken({
+          link["."]["authorization"] = await this.GenerateSignedLinkToken({
             containerId: info.authContainer,
             versionHash: info.targetHash,
             link: `./${type}/${authTarget}`


### PR DESCRIPTION
- Export and move `GenerateSignedLinkToken`
- Do not set permission in `CopyContentObject`. If a kms cap is present, generate a new encryption conk