### PR TITLE
Changes to support node ingest API enhancements and new scripts

### DIFF
--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -22,8 +22,8 @@ class HttpClient {
     return Fetch(url, params);
   }
 
-  RecordWriteToken(writeToken, uri = this.BaseURI()) {
-    this.draftURIs[writeToken] = uri;
+  RecordWriteToken(writeToken, nodeUrlStr) {
+    this.draftURIs[writeToken] = nodeUrlStr ? new URI(nodeUrlStr) : this.BaseURI();
   }
 
   RequestHeaders(bodyType, headers={}) {

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -22,8 +22,8 @@ class HttpClient {
     return Fetch(url, params);
   }
 
-  RecordWriteToken(writeToken) {
-    this.draftURIs[writeToken] = this.BaseURI();
+  RecordWriteToken(writeToken, uri = this.BaseURI()) {
+    this.draftURIs[writeToken] = uri;
   }
 
   RequestHeaders(bodyType, headers={}) {
@@ -54,7 +54,7 @@ class HttpClient {
     let baseURI = this.BaseURI();
 
     // If URL contains a write token, it must go to the correct server and can not fail over
-    const writeTokenMatch = path.replace(/^\//, "").match(/(qlibs\/ilib[a-zA-Z0-9]+|q|qid)\/(tqw_[a-zA-Z0-9]+)/);
+    const writeTokenMatch = path.replace(/^\//, "").match(/(qlibs\/ilib[a-zA-Z0-9]+|q|qid)\/(tqw__[a-zA-Z0-9]+)/);
     const writeToken = writeTokenMatch ? writeTokenMatch[2] : undefined;
 
     if(writeToken) {


### PR DESCRIPTION
This extracts out just the changes made to `/src` in branch `mp-pr-media-api-enhancements` for easier review. It includes fix for write token detection.

 * New parameters for various ABR Publishing calls
   * Add `respLogLevel` and `structLogLevel` params to `CreateProductionMaster()` and `CreateABRMezzanine()`
   * Add `streamKeys`, `addlOfferingSpecs`, and `keepOtherStreams` params to `CreateABRMezzanine()`
   * Add `preFinalizeFn` and `preFinalizeThrow` params to `FinalizeABRMezzanine()` (allows post-processing of mez without incurring another edit/finalize cycle)
 * Extend `ContentObject()` to allow requesting information for drafts (the node url for write token must have already been registered via `HttpClient.RecordWriteToken`)
 * Write token handing fixes / extensions
   * Fix typo in write token detection regex in `HttpClient.Request()`
   * Extend `HttpClient.RecordWriteToken()` to allow recording node urls other than `this.BaseURI()` (if you pass in a node url string, gets converted to a `URI` object and stored)
   * Change `LROStatus()` to use `HttpClient.RecordWriteToken()` instead of `ElvClient.SetNodes()`
   * Change `EditContentObject()` to retrieve actual URL used from http response, extract node URL, record it using `HttpClient.RecordWriteToken()`, and include it in function return value
   * Enable `ContentObjectMetadata()` to distinguish between 'write token not found' (in which case an error will be thrown) and other 404 errors (which maintain old behavior of returning either `{}` or `undefined`)