### PR TITLE
Add service param to ElvClient

### DIFF
--- a/src/ElvClient.js
+++ b/src/ElvClient.js
@@ -139,7 +139,7 @@ class ElvClient {
    * @param {boolean=} noCache=false - If enabled, blockchain transactions will not be cached
    * @param {boolean=} noAuth=false - If enabled, blockchain authorization will not be performed
    * @param {boolean=} assumeV3=false - If enabled, V3 fabric will be assumed
-   * @param {string=} clientMode=default - The mode that determines how HttpClient will be initialized.
+   * @param {string=} service=default - The mode that determines how HttpClient will be initialized.
    * If 'default' is set, HttpClient uris will use fabricUris. If 'search' is used, searchUris will be used
    *
    * @return {ElvClient} - New ElvClient connected to the specified content fabric and blockchain
@@ -159,7 +159,7 @@ class ElvClient {
     noCache=false,
     noAuth=false,
     assumeV3=false,
-    clientMode="default"
+    service="default"
   }) {
     this.utils = Utils;
 
@@ -184,7 +184,12 @@ class ElvClient {
     this.noCache = noCache;
     this.noAuth = noAuth;
     this.assumeV3 = assumeV3;
-    this.clientMode = clientMode;
+
+    if(!["search", "default"].includes(this.service)) {
+      throw Error(`Invalid service: ${this.service}`);
+    }
+
+    this.service = service;
 
     this.debug = false;
 
@@ -378,7 +383,7 @@ class ElvClient {
     this.visibilityInfo = {};
     this.inaccessibleLibraries = {};
 
-    const uris = this.clientMode === "search" ? this.searchURIs : this.fabricURIs;
+    const uris = this.service === "search" ? this.searchURIs : this.fabricURIs;
     this.HttpClient = new HttpClient({uris, debug: this.debug});
     this.AuthHttpClient = new HttpClient({uris: this.authServiceURIs, debug: this.debug});
     this.ethClient = new EthClient({client: this, uris: this.ethereumURIs, networkId: this.networkId, debug: this.debug, timeout: this.ethereumContractTimeout});

--- a/src/FrameClient.js
+++ b/src/FrameClient.js
@@ -416,7 +416,6 @@ class FrameClient {
       "PublicRep",
       "PublishContentVersion",
       "QParts",
-      "RecordWriteToken",
       "RedeemCode",
       "RemoveAccessGroupManager",
       "RemoveAccessGroupMember",

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -14,8 +14,8 @@ class HttpClient {
     this.draftURIs = {};
   }
 
-  BaseURI(url) {
-    return new URI(url || this.uris[this.uriIndex]);
+  BaseURI() {
+    return new URI(this.uris[this.uriIndex]);
   }
 
   static Fetch(url, params={}) {
@@ -49,11 +49,9 @@ class HttpClient {
     headers={},
     attempts=0,
     failover=true,
-    forceFailover=false,
-    nodeUrl
+    forceFailover=false
   }) {
-    // if nodeUrl passed in, restrict communication to that node only (unless previously recorded write token is found in next step)
-    let baseURI = this.BaseURI(nodeUrl);
+    let baseURI = this.BaseURI();
 
     // If URL contains a write token, it must go to the correct server and can not fail over
     const writeTokenMatch = path.replace(/^\//, "").match(/(qlibs\/ilib[a-zA-Z0-9]+|q|qid)\/(tqw__[a-zA-Z0-9]+)/);
@@ -107,7 +105,7 @@ class HttpClient {
 
     if(!response.ok) {
       // Fail over if not a write token request, the response was a server error, and we haven't tried all available nodes
-      if(!writeToken && !nodeUrl && ((failover && parseInt(response.status) >= 500) || forceFailover) && attempts < this.uris.length) {
+      if(!writeToken && ((failover && parseInt(response.status) >= 500) || forceFailover) && attempts < this.uris.length) {
         // Server error - Try next node
         this.Log(`HttpClient failing over from ${this.BaseURI()}: ${attempts + 1} attempts`, true);
         this.uriIndex = (this.uriIndex + 1) % this.uris.length;

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -749,7 +749,6 @@ exports.CreateNonOwnerCap = async function({objectId, libraryId, publicKey, writ
  * @param {object=} options -
  * meta: New metadata for the object - will be merged into existing metadata if specified
  * type: New type for the object - Object ID, version hash or name of type
- * nodeUrl: Node URL to use in HTTP call
  *
  * @returns {Promise<object>} - Response containing the object ID and write token of the draft, as well as URL of node handling the draft
  */
@@ -779,8 +778,7 @@ exports.EditContentObject = async function({libraryId, objectId, options={}}) {
     headers: await this.authClient.AuthorizationHeader({libraryId, objectId, update: true}),
     method: "POST",
     path: path,
-    body: options,
-    nodeUrl: options.nodeUrl
+    body: options
   });
 
   const actualUrl = new URL(rawEditResponse.url);


### PR DESCRIPTION
Add `clientMode` to the ElvClient constructor, which is set to "default" if no value is provided. When clientMode === "search", the HttpClient uris are set to use the searchUris. Otherwise, the fabricUris are used.
This allows calling CallFromFrameMessage from the appropriate client in elv-core-js.
Additionally, remove `RecordWriteToken` from allowed FrameClient methods.