### PR TITLE
Pass undefined exp to GenerateSignedLinkToken when not provided

### DIFF
--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -1349,7 +1349,7 @@ exports.GenerateSignedLinkToken = async function({
     sub: `iusr${this.utils.AddressToHash(signerAddress)}`,
     gra: "read",
     iat: Date.now(),
-    exp: duration ? (Date.now() + duration) : "",
+    exp: duration ? (Date.now() + duration) : undefined,
     ctx: {
       elv: {
         lnk: link,


### PR DESCRIPTION
When `duration` is not provided to GenerateSignedLinksToken(), set `exp` as undefined instead of an empty string. Relates to https://github.com/eluv-io/elv-fabric-browser/issues/33#issuecomment-1485965313