### PR TITLE
Catch error for countVersionHashes to throw proper error message

### DIFF
--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -1099,10 +1099,14 @@ exports.LatestVersionHash = async function({objectId, versionHash}) {
   } catch(error) {}
 
   if(!latestHash) {
-    const versionCount = await this.CallContractMethod({
-      contractAddress: this.utils.HashToAddress(objectId),
-      methodName: "countVersionHashes"
-    });
+    let versionCount;
+    try {
+      versionCount = await this.CallContractMethod({
+        contractAddress: this.utils.HashToAddress(objectId),
+        methodName: "countVersionHashes"
+      });
+    // eslint-disable-next-line no-empty
+    } catch(error) {}
 
     if(!versionCount.toNumber()) {
       throw Error(`Unable to determine latest version hash for ${versionHash || objectId} - Item deleted?`);


### PR DESCRIPTION
Add try/catch to contract method call for "countVersionHashes" to show proper error for a deleted object.
Relates to https://github.com/eluv-io/elv-fabric-browser/issues/79