### PR TITLE
Handle latest version hash error when versionCount is undefined

### DIFF
--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -1108,7 +1108,7 @@ exports.LatestVersionHash = async function({objectId, versionHash}) {
     // eslint-disable-next-line no-empty
     } catch(error) {}
 
-    if(!versionCount.toNumber()) {
+    if(!versionCount || !versionCount.toNumber()) {
       throw Error(`Unable to determine latest version hash for ${versionHash || objectId} - Item deleted?`);
     }
 


### PR DESCRIPTION
When an item has been deleted, countVersionHashes returns `undefined`, which causes `versionCount.toNumber()` to throw a type error. Handle this case so that the correct error message is displayed to the user.