### PR TITLE
Add searchable_links to defaultSpec

### DIFF
--- a/typeSpecs/Default.js
+++ b/typeSpecs/Default.js
@@ -74,6 +74,12 @@ const defaultSpec = {
       defaultable: false,
       orderable: true
     }
+  ],
+  searchable_links: [
+    {target: "/public/asset_metadata", link_key: "asset_metadata"},
+    {target: "/public/assets", link_key: "assets"},
+    {target: "/offerings", link_key: "offerings"},
+    {target: "/video_tags", link_key: "video_tags"}
   ]
 };
 

--- a/typeSpecs/MainSite.js
+++ b/typeSpecs/MainSite.js
@@ -6,6 +6,7 @@ const mainSiteSelectorSpec = {
     version: "0.1",
   },
   manageApp: "default",
+  show_searchables_tab: true,
   controls: [
     "images",
   ],


### PR DESCRIPTION
This will be used in Asset Manager when initializing searchable link values and in the event of loading a Default profile.