### PR TITLE
Issue #398 - Library Contract with _ELV_TENANT_ID

### DIFF
--- a/src/ElvClient.js
+++ b/src/ElvClient.js
@@ -619,6 +619,12 @@ class ElvClient {
    * @param {object} signer - The ethers.js signer object
    */
   SetSigner({signer, reset=true}) {
+    //Check if tenant contract id exists before connecting to ethClient.
+    this.signer = signer;
+    if (!this.client.userProfileCLient.TenantContractId()) {
+      throw Error("Error: The account associated to this signer doesn't have an associated tenant contract id");
+    }
+
     this.staticToken = undefined;
 
     signer.connect(this.ethClient.Provider());
@@ -628,9 +634,6 @@ class ElvClient {
     if(reset) {
       this.InitializeClients();
     }
-
-    if (!this.client.userProfileCLient.TenantContractId()) {
-      throw Error("Error: The user doesn't have an associated tenant contract id");
   }
 
   /**

--- a/src/ElvClient.js
+++ b/src/ElvClient.js
@@ -628,6 +628,9 @@ class ElvClient {
     if(reset) {
       this.InitializeClients();
     }
+
+    if (!this.client.userProfileCLient.TenantContractId()) {
+      throw Error("Error: The user doesn't have an associated tenant contract id");
   }
 
   /**

--- a/src/ElvClient.js
+++ b/src/ElvClient.js
@@ -637,7 +637,7 @@ class ElvClient {
    * @namedParams
    * @param {string=} idToken - OAuth ID token
    * @param {string=} authToken - Eluvio authorization token previously issued from OAuth ID token
-   * @param {string=} tenantId - If specified, user will be associated with the tenant
+   * @param {string=} tenantId - If specified, user will be associated with the tenant admins group
    * @param {Object=} extraData - Additional data to pass to the login API
    * @param {Array<string>=} signerURIs - (Only if using custom OAuth) - URIs corresponding to the key server(s) to use
    * @param {boolean=} unsignedPublicAuth=false - If specified, the client will use an unsigned static token for calls that don't require authorization (reduces remote signature calls)
@@ -716,7 +716,7 @@ class ElvClient {
     await this.userProfileClient.CreateWallet();
 
     await this.userProfileClient.ReplaceUserMetadata({
-      metadataSubtree: "tenantContractId",
+      metadataSubtree: "_ELV_TENANT_ID",
       metadata: tenantId
     });
 

--- a/src/ElvClient.js
+++ b/src/ElvClient.js
@@ -716,7 +716,7 @@ class ElvClient {
     await this.userProfileClient.CreateWallet();
 
     await this.userProfileClient.ReplaceUserMetadata({
-      metadataSubtree: "_ELV_TENANT_ID",
+      metadataSubtree: "tenantContractId",
       metadata: tenantId
     });
 

--- a/src/UserProfileClient.js
+++ b/src/UserProfileClient.js
@@ -472,7 +472,7 @@ await client.userProfileClient.UserMetadata()
   /**
    * Return the ID of the tenant contract this user belongs to, if set.
    *
-   * @return {Promise<string>} - Tenant ID
+   * @return {Promise<string>} - Tenant Contract ID
    */
   async TenantContractId() {
     if(!this.tenantContractId) {

--- a/src/UserProfileClient.js
+++ b/src/UserProfileClient.js
@@ -476,7 +476,7 @@ await client.userProfileClient.UserMetadata()
    */
   async TenantContractId() {
     if(!this.tenantContractId) {
-      this.tenantContractId = await this.UserMetadata({metadataSubtree: "_ELV_TENANT_ID"});
+      this.tenantContractId = await this.UserMetadata({metadataSubtree: "tenantContractId"});
     }
 
     return this.tenantContractId;
@@ -488,12 +488,12 @@ await client.userProfileClient.UserMetadata()
    * Note: This method is not accessible to applications. Eluvio core will drop the request.
    *
    * @namedParams
-   * @param {string} tenantContractID - The tenant contract ID in hash format
+   * @param {string} tenantContractId - The tenant contract ID in hash format
    * @param {string} address - The group address to use in the hash if id is not provided
    */
-  async SetTenantContractId({tenantContractID, address}) {
-    if(tenantContractID && (!tenantContractID.startsWith("iten") || !Utils.ValidHash(tenantContractID))) {
-      throw Error(`Invalid tenant ID: ${id}`);
+  async SetTenantContractId({tenantContractId, address}) {
+    if(tenantContractId && (!tenantContractId.startsWith("iten") || !Utils.ValidHash(tenantContractId))) {
+      throw Error(`Invalid tenant ID: ${tenantContractId}`);
     }
 
     if(address) {
@@ -501,20 +501,20 @@ await client.userProfileClient.UserMetadata()
         throw Error(`Invalid address: ${address}`);
       }
 
-      tenantContractID = `iten${Utils.AddressToHash(address)}`;
+      tenantContractId = `iten${Utils.AddressToHash(address)}`;
     }
 
     try {
-      const version = await this.client.AccessType({tenantContractID});
+      const version = await this.client.AccessType({tenantContractId});
 
       if(version !== this.client.authClient.ACCESS_TYPES.TENANT) {
-        throw Error("Invalid tenant ID: " + tenantContractID);
+        throw Error("Invalid tenant ID: " + tenantContractId);
       }
     } catch(error) {
-      throw Error("Invalid tenant ID: " + tenantContractID);
+      throw Error("Invalid tenant ID: " + tenantContractId);
     }
 
-    await this.ReplaceUserMetadata({metadataSubtree: "_ELV_TENANT_ID", metadata: tenantContractID});
+    await this.ReplaceUserMetadata({metadataSubtree: "tenantContractId", metadata: tenantContractId});
   }
 
   /**

--- a/src/UserProfileClient.js
+++ b/src/UserProfileClient.js
@@ -438,7 +438,7 @@ await client.userProfileClient.UserMetadata()
    * Note: This method is not accessible to applications. Eluvio core will drop the request.
    *
    * @namedParams
-   * @param {string} id - The tenant ID in hash format
+   * @param {string} id - The tenant admins ID in hash format
    * @param {string} address - The group address to use in the hash if id is not provided
    */
   async SetTenantId({id, address}) {
@@ -475,11 +475,11 @@ await client.userProfileClient.UserMetadata()
    * @return {Promise<string>} - Tenant ID
    */
   async TenantContractId() {
-    if(!this._ELV_TENANT_ID) {
-      this._ELV_TENANT_ID = await this.UserMetadata({metadataSubtree: "_ELV_TENANT_ID"});
+    if(!this.tenantContractId) {
+      this.tenantContractId = await this.UserMetadata({metadataSubtree: "_ELV_TENANT_ID"});
     }
 
-    return this.tenantId;
+    return this.tenantContractId;
   }
 
   /**
@@ -488,11 +488,11 @@ await client.userProfileClient.UserMetadata()
    * Note: This method is not accessible to applications. Eluvio core will drop the request.
    *
    * @namedParams
-   * @param {string} id - The tenant contract ID in hash format
+   * @param {string} tenantContractID - The tenant contract ID in hash format
    * @param {string} address - The group address to use in the hash if id is not provided
    */
-  async SetTenantContractId({id, address}) {
-    if(id && (!id.startsWith("iten") || !Utils.ValidHash(id))) {
+  async SetTenantContractId({tenantContractID, address}) {
+    if(tenantContractID && (!tenantContractID.startsWith("iten") || !Utils.ValidHash(tenantContractID))) {
       throw Error(`Invalid tenant ID: ${id}`);
     }
 
@@ -501,20 +501,20 @@ await client.userProfileClient.UserMetadata()
         throw Error(`Invalid address: ${address}`);
       }
 
-      id = `iten${Utils.AddressToHash(address)}`;
+      tenantContractID = `iten${Utils.AddressToHash(address)}`;
     }
 
     try {
-      const version = await this.client.AccessType({id});
+      const version = await this.client.AccessType({tenantContractID});
 
       if(version !== this.client.authClient.ACCESS_TYPES.TENANT) {
-        throw Error("Invalid tenant ID: " + id);
+        throw Error("Invalid tenant ID: " + tenantContractID);
       }
     } catch(error) {
-      throw Error("Invalid tenant ID: " + id);
+      throw Error("Invalid tenant ID: " + tenantContractID);
     }
 
-    await this.ReplaceUserMetadata({metadataSubtree: "_ELV_TENANT_ID", metadata: id});
+    await this.ReplaceUserMetadata({metadataSubtree: "_ELV_TENANT_ID", metadata: tenantContractID});
   }
 
   /**

--- a/src/Validation.js
+++ b/src/Validation.js
@@ -14,31 +14,6 @@ exports.ValidateLibrary = (libraryId) => {
   }
 };
 
-//New Gen: Support new tenant object
-exports.ValidateLibraryNG = async (libraryId) => {
-  if(!libraryId) {
-    throw Error("Library ID not specified");
-  } else if(!libraryId.toString().startsWith("i")) {
-    throw Error(`Invalid library ID: ${libraryId}`);
-  }
-
-  let libraryAddress = client.utils.HashToAddress(libraryId).toLowerCase();
-  try {
-    await client.CallContractMethod({
-      contractAddress: libraryAddress,
-      methodName: "getMeta",
-      methodArgs: [
-        " _ELV_TENANT_ID"
-      ]
-    });
-  } catch(e) {
-    throw Error(`The library with id: ${libraryId} doesn't have an _ELV_TENANT_ID tag`)
-  }
-};
-
-//New Gen: Support new content type object
-exports.ValidateContentType = async (libraryId) => {}
-
 exports.ValidateObject = (objectId) => {
   if(!objectId) {
     throw Error("Object ID not specified");

--- a/src/Validation.js
+++ b/src/Validation.js
@@ -14,6 +14,27 @@ exports.ValidateLibrary = (libraryId) => {
   }
 };
 
+//New Gen: Support new tenant object
+exports.ValidateLibraryNG = async (libraryId) => {
+  if(!libraryId) {
+    throw Error("Library ID not specified");
+  } else if(!libraryId.toString().startsWith("i")) {
+    throw Error(`Invalid library ID: ${libraryId}`);
+  }
+
+  try {
+    await client.CallContractMethod({
+      contractAddress: client.utils.HashToAddress(libraryId),
+      methodName: "getMeta",
+      methodArgs: [
+        " _ELV_TENANT_ID"
+      ]
+    });
+  } catch(e) {
+    throw Error(`The library with id: ${libraryId} doesn't have an _ELV_TENANT_ID tag`)
+  }
+};
+
 exports.ValidateObject = (objectId) => {
   if(!objectId) {
     throw Error("Object ID not specified");

--- a/src/Validation.js
+++ b/src/Validation.js
@@ -36,6 +36,9 @@ exports.ValidateLibraryNG = async (libraryId) => {
   }
 };
 
+//New Gen: Support new content type object
+exports.ValidateContentType = async (libraryId) => {}
+
 exports.ValidateObject = (objectId) => {
   if(!objectId) {
     throw Error("Object ID not specified");

--- a/src/Validation.js
+++ b/src/Validation.js
@@ -24,7 +24,7 @@ exports.ValidateLibraryNG = async (libraryId) => {
 
   try {
     await client.CallContractMethod({
-      contractAddress: client.utils.HashToAddress(libraryId),
+      contractAddress: client.utils.HashToAddress(libraryId).toLowerCase(),
       methodName: "getMeta",
       methodArgs: [
         " _ELV_TENANT_ID"

--- a/src/Validation.js
+++ b/src/Validation.js
@@ -22,9 +22,10 @@ exports.ValidateLibraryNG = async (libraryId) => {
     throw Error(`Invalid library ID: ${libraryId}`);
   }
 
+  let libraryAddress = client.utils.HashToAddress(libraryId).toLowerCase();
   try {
     await client.CallContractMethod({
-      contractAddress: client.utils.HashToAddress(libraryId).toLowerCase(),
+      contractAddress: libraryAddress,
       methodName: "getMeta",
       methodArgs: [
         " _ELV_TENANT_ID"

--- a/src/client/AccessGroups.js
+++ b/src/client/AccessGroups.js
@@ -422,6 +422,7 @@ exports.RemoveAccessGroupManager = async function({contractAddress, memberAddres
  */
 exports.ContentLibraryGroupPermissions = async function({libraryId, permissions=[]}) {
   ValidateLibrary(libraryId);
+  VerifyLibrary(libraryId);
 
   let libraryPermissions = {};
 
@@ -491,6 +492,7 @@ exports.ContentLibraryGroupPermissions = async function({libraryId, permissions=
  */
 exports.AddContentLibraryGroup = async function({libraryId, groupAddress, permission}) {
   ValidateLibrary(libraryId);
+  VerifyLibrary(libraryId);
   groupAddress = ValidateAddress(groupAddress);
 
   if(!["accessor", "contributor", "reviewer"].includes(permission.toLowerCase())) {
@@ -535,6 +537,7 @@ exports.AddContentLibraryGroup = async function({libraryId, groupAddress, permis
  */
 exports.RemoveContentLibraryGroup = async function({libraryId, groupAddress, permission}) {
   ValidateLibrary(libraryId);
+  VerifyLibrary(libraryId);
   groupAddress = ValidateAddress(groupAddress);
 
   if(!["accessor", "contributor", "reviewer"].includes(permission.toLowerCase())) {

--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -386,6 +386,7 @@ exports.ContentLibraries = async function() {
  */
 exports.ContentLibrary = async function({libraryId}) {
   ValidateLibrary(libraryId);
+  VerifyLibrary(libraryid);
 
   const path = UrlJoin("qlibs", libraryId);
 
@@ -414,6 +415,7 @@ exports.ContentLibrary = async function({libraryId}) {
  */
 exports.ContentLibraryOwner = async function({libraryId}) {
   ValidateLibrary(libraryId);
+  VerifyLibrary(libraryId);
 
   return this.utils.FormatAddress(
     await this.ethClient.CallContractMethod({
@@ -439,6 +441,7 @@ exports.ContentLibraryOwner = async function({libraryId}) {
  */
 exports.LibraryContentTypes = async function({libraryId}) {
   ValidateLibrary(libraryId);
+  VerifyLibrary(libraryId);
 
   this.Log(`Retrieving library content types for ${libraryId}`);
 
@@ -498,6 +501,7 @@ exports.LibraryContentTypes = async function({libraryId}) {
  */
 exports.ContentObjects = async function({libraryId, filterOptions={}}) {
   ValidateLibrary(libraryId);
+  VerifyLibrary(libraryId);
 
   this.Log(`Retrieving content objects from ${libraryId}`);
 

--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -159,15 +159,15 @@ exports.Permission = async function({objectId, clearCache}) {
  *
  * @methodGroup Content Space
  * @namedParams
- * @param {string=} tenantContractId - An ID of a tenant contract - if not specified, the content space contract will be used
+ * @param {string=} tenantId - An ID of a tenant contract - if not specified, the content space contract will be used
  *
  * @returns {Promise<string>} - Address of the KMS
  */
-exports.DefaultKMSAddress = async function({tenantContractId}={}) {
+exports.DefaultKMSAddress = async function({tenantId}={}) {
   // Ensure tenant ID, if specified, is a tenant contract and not a group contract
-  if(tenantContractId && (await this.AccessType({id: tenantContractId})) === this.authClient.ACCESS_TYPES.TENANT) {
+  if(tenantId && (await this.AccessType({id: tenantId})) === this.authClient.ACCESS_TYPES.TENANT) {
     const kmsAddress = await this.CallContractMethod({
-      contractAddress: this.utils.HashToAddress(tenantContractId),
+      contractAddress: this.utils.HashToAddress(tenantId),
       methodName: "addressKMS",
     });
 

--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -163,7 +163,7 @@ exports.Permission = async function({objectId, clearCache}) {
  *
  * @returns {Promise<string>} - Address of the KMS
  */
-exports.DefaultKMSAddress = async function({tenantId}={}) {
+exports.DefaultKMSAddress = async function({tenantContractId}={}) {
   // Ensure tenant ID, if specified, is a tenant contract and not a group contract
   if(tenantContractId && (await this.AccessType({id: tenantContractId})) === this.authClient.ACCESS_TYPES.TENANT) {
     const kmsAddress = await this.CallContractMethod({

--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -159,15 +159,15 @@ exports.Permission = async function({objectId, clearCache}) {
  *
  * @methodGroup Content Space
  * @namedParams
- * @param {string=} tenantId - An ID of a tenant contract - if not specified, the content space contract will be used
+ * @param {string=} tenantContractId - An ID of a tenant contract - if not specified, the content space contract will be used
  *
  * @returns {Promise<string>} - Address of the KMS
  */
 exports.DefaultKMSAddress = async function({tenantId}={}) {
   // Ensure tenant ID, if specified, is a tenant contract and not a group contract
-  if(tenantId && (await this.AccessType({id: tenantId})) === this.authClient.ACCESS_TYPES.TENANT) {
+  if(tenantContractId && (await this.AccessType({id: tenantContractId})) === this.authClient.ACCESS_TYPES.TENANT) {
     const kmsAddress = await this.CallContractMethod({
-      contractAddress: this.utils.HashToAddress(tenantId),
+      contractAddress: this.utils.HashToAddress(tenantContractId),
       methodName: "addressKMS",
     });
 

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -161,7 +161,7 @@ exports.CreateContentType = async function({name, metadata={}, bitcode}) {
     throw(e, "ERROR: Can not find metadata _ELV_TENANT_ID that belongs to this user");
   }
   //Content Type can only be created by tenant admins or content admins
-  if(!this.TenantAdmin(tenantContractId) && !this.isContentAdmin(tenantContractId)) {
+  if(!this.isTenantAdmin(tenantContractId) && !this.isContentAdmin(tenantContractId)) {
     throw Error("Invalid operation: Content Type can only be created by tenant admins or content admins");
   }
 

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -161,7 +161,8 @@ exports.CreateContentType = async function({name, metadata={}, bitcode}) {
     throw(e, "ERROR: Can not find metadata _ELV_TENANT_ID that belongs to this user");
   }
   //Content Type can only be created by tenant admins or content admins
-  if(!this.isTenantAdmin(tenantContractId) && !this.isContentAdmin(tenantContractId)) {
+  let curAccountId = "iten" + this.utils.AddressToHash(this.currentAccountAddress)
+  if(!this.isTenantAdmin(curAccountId, tenantContractId) && !this.isContentAdmin(curAccountId, tenantContractId)) {
     throw Error("Invalid operation: Content Type can only be created by tenant admins or content admins");
   }
 
@@ -300,7 +301,7 @@ exports.CreateContentLibrary = async function({
 
   const { contractAddress } = await this.authClient.CreateContentLibrary({kmsId});
 
-  // Legacy: Set tenant admins ID on the library if the user is associated with a tenant admins' group
+  // Set tenant admins ID on the library if the user is associated with a tenant admins' group
   if(!tenantId) {
     tenantId = await this.userProfileClient.TenantId();
   }
@@ -320,7 +321,7 @@ exports.CreateContentLibrary = async function({
     });
   }
 
-  // NG Tenant: Set _ELV_TEANT_ID on the library to the library creator's tenant id
+  // Set _ELV_TEANT_ID on the library to the library creator's tenant id
   await this.callContractMethod({
     contractAddress,
     methodName: "putMeta",
@@ -393,6 +394,7 @@ exports.CreateContentLibrary = async function({
  */
 exports.SetContentLibraryImage = async function({libraryId, writeToken, image, imageName}) {
   ValidateLibrary(libraryId);
+  VerifyLibrary(libraryId);
 
   const objectId = libraryId.replace("ilib", "iq__");
 
@@ -467,6 +469,7 @@ exports.DeleteContentLibrary = async function({libraryId}) {
 
   // eslint-disable-next-line no-unreachable
   ValidateLibrary(libraryId);
+  VerifyLibrary(libraryId);
 
   let path = UrlJoin("qlibs", libraryId);
 
@@ -503,6 +506,8 @@ exports.DeleteContentLibrary = async function({libraryId}) {
  */
 exports.AddLibraryContentType = async function({libraryId, typeId, typeName, typeHash, customContractAddress}) {
   ValidateLibrary(libraryId);
+  VerifyLibrary(libraryId);
+  VerifyContentType(typeId);
 
   this.Log(`Adding library content type to ${libraryId}: ${typeId || typeHash || typeName}`);
 
@@ -542,6 +547,7 @@ exports.AddLibraryContentType = async function({libraryId, typeId, typeName, typ
  */
 exports.RemoveLibraryContentType = async function({libraryId, typeId, typeName, typeHash}) {
   ValidateLibrary(libraryId);
+  VerifyLibrary(libraryId);
 
   this.Log(`Removing library content type from ${libraryId}: ${typeId || typeHash || typeName}`);
 
@@ -589,6 +595,7 @@ exports.RemoveLibraryContentType = async function({libraryId, typeId, typeName, 
  */
 exports.CreateContentObject = async function({libraryId, objectId, options={}}) {
   ValidateLibrary(libraryId);
+  VerifyLibrary(libraryId);
   if(objectId) { ValidateObject(objectId); }
 
   this.Log(`Creating content object: ${libraryId} ${objectId || ""}`);
@@ -794,6 +801,7 @@ exports.CreateNonOwnerCap = async function({objectId, libraryId, publicKey, writ
  */
 exports.EditContentObject = async function({libraryId, objectId, options={}}) {
   ValidateParameters({libraryId, objectId});
+  VerifyLibrary(libraryId);
 
   this.Log(`Opening content draft: ${libraryId} ${objectId}`);
 

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -257,9 +257,7 @@ exports.CreateContentLibrary = async function({
   kmsId,
   tenantId
 }) {
-  const signerAddress = this.currentAccountAddress();
-  const signerId = "iten" + Utils.AddressToHash(signerAddress);
-
+  
   let tenantContractId;
   try {
   tenantContractId = this.userProfileClient.tenantContractId();
@@ -306,7 +304,7 @@ exports.CreateContentLibrary = async function({
     methodName: "putMeta",
     methodArgs: [
       "_ELV_TENANT_ID",
-      signerId
+      tenantContractId
     ]
   })
 

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -1554,13 +1554,13 @@ exports.SetAuthPolicy = async function({objectId, policyId}) {
  * @namedParams
  * @param {string} tenantId - The ID of the tenant
  */
-exports.IsOwnTenantAdmin = async function({ tenantId }) {
+exports.IsTenantAdmin = async function({ tenantId }) {
   const tenantAddr = Utils.HashToAddress(tenantId);
 
   let tenantAdminAddr = await this.client.CallContractMethod({
     contractAddress: tenantAddr,
-    methodName: "groupsMapping",
-    methodArgs: ["tenant_admin", 0],
+    methodName: "isAdmin",
+    methodArgs: [tenantAddr],
     formatArguments: true,
   });
 
@@ -1575,7 +1575,7 @@ exports.IsOwnTenantAdmin = async function({ tenantId }) {
  * @namedParams
  * @param {string} tenantId - The ID of the tenant
  */
-exports.IsOwnContentAdmin = async function({ tenantId }) {
+exports.IsContentAdmin = async function({ tenantId }) {
   const tenantAddr = Utils.HashToAddress(tenantId);
 
   for (let i = 0; i < Number.MAX_SAFE_INTEGER; i++) {

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -258,9 +258,10 @@ exports.CreateContentLibrary = async function({
   tenantId
 }) {
   const signerAddress = this.currentAccountAddress();
+  const signerId = "iten" + Utils.AddressToHash(signerAddress);
 
   //Library can only be created by tenant admins or content admins
-  if(!IsOwnTenantAdmin && !isOwnContentAdmin) {
+  if(!this.IsOwnTenantAdmin(signerId) && !this.isOwnContentAdmin(signerId)) {
     throw Error("Invalid operation: Library can only be created by tenant admins or content admins");
   }
 
@@ -274,7 +275,7 @@ exports.CreateContentLibrary = async function({
   const { contractAddress } = await this.authClient.CreateContentLibrary({kmsId});
 
 
-  // Legacy: Set tenant ID on the library if the user is associated with a tenant admin group
+  // Legacy: Set tenant ID on the library if the user is associated with a tenant admins' group
   if(!tenantId) {
     tenantId = await this.userProfileClient.TenantId();
   }
@@ -295,7 +296,6 @@ exports.CreateContentLibrary = async function({
   }
 
   // NG Tenant: Set _ELV_TEANT_ID on the library to the library creator's tenant id
-  const signerId = "iten" + Utils.AddressToHash(signerAddress);
   await this.callContractMethod({
     contractAddress,
     methodName: "putMeta",

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -1554,7 +1554,7 @@ exports.SetAuthPolicy = async function({objectId, policyId}) {
  * @namedParams
  * @param {string} tenantId - The ID of the tenant
  */
-IsOwnTenantAdmin = async function({ tenantId }) {
+exports.IsOwnTenantAdmin = async function({ tenantId }) {
   const tenantAddr = Utils.HashToAddress(tenantId);
 
   let tenantAdminAddr = await this.client.CallContractMethod({
@@ -1575,7 +1575,7 @@ IsOwnTenantAdmin = async function({ tenantId }) {
  * @namedParams
  * @param {string} tenantId - The ID of the tenant
  */
-IsOwnContentAdmin = async function({ tenantId }) {
+exports.IsOwnContentAdmin = async function({ tenantId }) {
   const tenantAddr = Utils.HashToAddress(tenantId);
 
   for (let i = 0; i < Number.MAX_SAFE_INTEGER; i++) {

--- a/test/ElvClient.test.js
+++ b/test/ElvClient.test.js
@@ -321,7 +321,7 @@ describe("Test ElvClient", () => {
 
       expect(privateMetadata).toEqual({meta: "data"});
 
-      const libraryTenant = await client.CallContractMethod({
+      const libraryAdminGroupAddr = await client.CallContractMethod({
         contractAddress: client.utils.HashToAddress(libraryId),
         methodName: "getMeta",
         methodArgs: [
@@ -330,9 +330,21 @@ describe("Test ElvClient", () => {
       });
 
       const tenantId = `iten${client.utils.AddressToHash(accessGroupAddress)}`;
-      const libraryTenantId = Buffer.from(libraryTenant.replace("0x", ""), "hex").toString("utf8");
+      const libraryAdminGroupId = Buffer.from(libraryAdminGroupAddr.replace("0x", ""), "hex").toString("utf8");
 
-      expect(libraryTenantId).toEqual(tenantId);
+      expect(libraryAdminGroupId).toEqual(tenantId);
+
+      const libraryOwner = await client.CallContractMethod({
+        contractAddress: client.utils.HashToAddress(libraryId),
+        methodName: "getMeta",
+        methodArgs: [
+          "_ELV_TENANT_ID"
+        ]
+      });
+
+      const ownerId = `iten${client.utils.AddressToHash(client.signer.address)}`;
+
+      expect(libraryOwnerId).toEqual(ownerId);
 
       console.log(`\n\nLibraryId: ${libraryId}\nTenant ID: ${tenantId}\n`);
     });

--- a/test/ElvClient.test.js
+++ b/test/ElvClient.test.js
@@ -329,12 +329,12 @@ describe("Test ElvClient", () => {
         ]
       });
 
-      const tenantId = `iten${client.utils.AddressToHash(accessGroupAddress)}`;
+      const tenantAdminsGroupId = `iten${client.utils.AddressToHash(accessGroupAddress)}`;
       const libraryAdminsGroupId = Buffer.from(libraryAdminsGroupAddr.replace("0x", ""), "hex").toString("utf8");
 
-      expect(libraryAdminsGroupId).toEqual(tenantId);
+      expect(libraryAdminsGroupId).toEqual(tenantAdminsGroupId);
 
-      const libraryOwnerId = await client.CallContractMethod({
+      const tenantContractId = await client.CallContractMethod({
         contractAddress: client.utils.HashToAddress(libraryId),
         methodName: "getMeta",
         methodArgs: [
@@ -342,11 +342,11 @@ describe("Test ElvClient", () => {
         ]
       });
 
-      const ownerId = `iten${client.utils.AddressToHash(client.signer.address)}`;
+      const libraryTenantContractId = `iten${client.userProfileClient.tenantContractId()}`;
 
-      expect(libraryOwnerId).toEqual(ownerId);
+      expect(libraryTenantContractId).toEqual(tenantContractId);
 
-      console.log(`\n\nLibraryId: ${libraryId}\nTenant ID: ${tenantId}\n`);
+      console.log(`\n\nLibraryId: ${libraryId}\nTenant Admins Group ID: ${libraryAdminsGroupId}\nTenant Contract ID: ${tenantContractId}\n`);
     });
 
     test("Clear Tenancy", async () => {

--- a/test/ElvClient.test.js
+++ b/test/ElvClient.test.js
@@ -321,7 +321,7 @@ describe("Test ElvClient", () => {
 
       expect(privateMetadata).toEqual({meta: "data"});
 
-      const libraryAdminGroupAddr = await client.CallContractMethod({
+      const libraryAdminsGroupAddr = await client.CallContractMethod({
         contractAddress: client.utils.HashToAddress(libraryId),
         methodName: "getMeta",
         methodArgs: [
@@ -330,11 +330,11 @@ describe("Test ElvClient", () => {
       });
 
       const tenantId = `iten${client.utils.AddressToHash(accessGroupAddress)}`;
-      const libraryAdminGroupId = Buffer.from(libraryAdminGroupAddr.replace("0x", ""), "hex").toString("utf8");
+      const libraryAdminsGroupId = Buffer.from(libraryAdminsGroupAddr.replace("0x", ""), "hex").toString("utf8");
 
-      expect(libraryAdminGroupId).toEqual(tenantId);
+      expect(libraryAdminsGroupId).toEqual(tenantId);
 
-      const libraryOwner = await client.CallContractMethod({
+      const libraryOwnerId = await client.CallContractMethod({
         contractAddress: client.utils.HashToAddress(libraryId),
         methodName: "getMeta",
         methodArgs: [
@@ -350,7 +350,7 @@ describe("Test ElvClient", () => {
     });
 
     test("Clear Tenancy", async () => {
-      // Remove the tenant ID from the library
+      // Remove the tenant admins group ID from the library
       await client.CallContractMethodAndWait({
         contractAddress: client.utils.HashToAddress(libraryId),
         methodName: "putMeta",

--- a/testScripts/InitializeTenant.js
+++ b/testScripts/InitializeTenant.js
@@ -173,7 +173,7 @@ const InitializeTenant = async ({configUrl, kmsId, tenantName}) => {
       memberAddress: client.utils.HashToAddress(kmsId)
     });
 
-    console.log("\nTenant ID:\n");
+    console.log("\nTenant Admins ID:\n");
     console.log("\t", await client.userProfileClient.TenantId());
 
     console.log("\nAccess Groups:\n");


### PR DESCRIPTION
[ISSUES #398](https://github.com/qluvio/info/issues/398)
- Change `tenant` to `tenant admins` or `tenant` to `tenant contract` in comments/code for clarity.
- Add functions `tenantContractId` and `setTenantContractId` to retrieve/set `_ELV_TENANT_ID `from user's metadata.
- In CreateContentLibrary, first check if the user is associated with a tenant, then check if they are in either the tenant's content admins group or tenant admins group. Throw an error if any of the conditions are not met.
- Add _ELV_TENANT_ID to library's metadata when created.
- Created helper functions to aid the procedures above (IsTenantAdmin, IsContentAdmin).
- Add _ELV_TENANT_ID to contentType's metadata when created.
- Add libraryVerification to functions.