### PR TITLE
Add valid part hash prefixes

### DIFF
--- a/src/Validation.js
+++ b/src/Validation.js
@@ -41,7 +41,13 @@ exports.ValidateWriteToken = (writeToken) => {
 exports.ValidatePartHash = (partHash) => {
   if(!partHash) {
     throw Error("Part hash not specified");
-  } else if(!partHash.toString().startsWith("hqp_") && !partHash.toString().startsWith("hqpe")) {
+  }
+  else if(!partHash.toString().startsWith("hqp_") &&
+          !partHash.toString().startsWith("hqpe") &&
+          !partHash.toString().startsWith("hqt_") &&
+          !partHash.toString().startsWith("hqte") &&
+          !partHash.toString().startsWith("hql_") &&
+          !partHash.toString().startsWith("hqle")) {
     throw Error(`Invalid part hash: ${partHash}`);
   }
 };


### PR DESCRIPTION
Added a few new 'content part' prefixes.

Content Fabric reference:  https://github.com/eluv-io/common-go/blob/ad39b8825f76ca44ca45cd56a6424687e783b34b/format/hash/hash.go#L125C1-L125C1