### PR TITLE
Deep copy Live conf template when generating config

### DIFF
--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -236,7 +236,7 @@ class LiveConf {
     return sync_id;
   }
 
-  generateLiveConf() {
+  generateLiveConf({audioBitrate, audioIndex, partTtl}) {
     // gather required data
     const conf = JSON.parse(JSON.stringify(LiveconfTemplate));
     const fileName = this.overwriteOriginUrl || this.probeData.format.filename;
@@ -255,13 +255,21 @@ class LiveConf {
     conf.live_recording.recording_config.recording_params.origin_url = fileName;
     conf.live_recording.recording_config.recording_params.description = `Ingest stream ${fileName}`;
     conf.live_recording.recording_config.recording_params.name = `Ingest stream ${fileName}`;
-    conf.live_recording.recording_config.recording_params.xc_params.audio_index[0] = audioStream.stream_index;
+    conf.live_recording.recording_config.recording_params.xc_params.audio_index[0] = audioIndex === undefined ? audioStream.stream_index : audioIndex;
     conf.live_recording.recording_config.recording_params.xc_params.sample_rate = sampleRate;
     conf.live_recording.recording_config.recording_params.xc_params.enc_height = videoStream.height;
     conf.live_recording.recording_config.recording_params.xc_params.enc_width = videoStream.width;
 
     if(this.syncAudioToVideo) {
       conf.live_recording.recording_config.recording_params.xc_params.sync_audio_to_stream_id = this.syncAudioToStreamIdValue();
+    }
+
+    if(audioBitrate) {
+      conf.live_recording.recording_config.recording_params.xc_params.audio_bitrate = audioBitrate;
+    }
+
+    if(partTtl) {
+      conf.live_recording.recording_config.recording_params.part_ttl = partTtl;
     }
 
     // Fill in specifics for protocol

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -238,7 +238,7 @@ class LiveConf {
 
   generateLiveConf() {
     // gather required data
-    const conf = LiveconfTemplate;
+    const conf = JSON.parse(JSON.stringify(LiveconfTemplate));
     const fileName = this.overwriteOriginUrl || this.probeData.format.filename;
     const audioStream = this.getStreamDataForCodecType("audio");
     const sampleRate = parseInt(audioStream.sample_rate);

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -236,7 +236,7 @@ class LiveConf {
     return sync_id;
   }
 
-  generateLiveConf({audioBitrate, audioIndex, partTtl}) {
+  generateLiveConf({audioBitrate, audioIndex, partTtl, channelLayout}) {
     // gather required data
     const conf = JSON.parse(JSON.stringify(LiveconfTemplate));
     const fileName = this.overwriteOriginUrl || this.probeData.format.filename;
@@ -262,10 +262,6 @@ class LiveConf {
 
     if(this.syncAudioToVideo) {
       conf.live_recording.recording_config.recording_params.xc_params.sync_audio_to_stream_id = this.syncAudioToStreamIdValue();
-    }
-
-    if(audioBitrate) {
-      conf.live_recording.recording_config.recording_params.xc_params.audio_bitrate = audioBitrate;
     }
 
     if(partTtl) {
@@ -351,6 +347,20 @@ class LiveConf {
         break;
       default:
         throw new Error("ERROR: Probed stream does not conform to one of the following built in resolution ladders [4096, 2160], [1920, 1080] [1280, 720], [960, 540], [640, 360]");
+    }
+
+    if(audioBitrate || channelLayout) {
+      const audioLadderSpec = conf.live_recording.recording_config.recording_params.ladder_specs.find(spec => spec.stream_name === "audio");
+
+      if(audioBitrate) {
+        conf.live_recording.recording_config.recording_params.xc_params.audio_bitrate = audioBitrate;
+        audioLadderSpec.bit_rate = audioBitrate;
+        audioLadderSpec.representation = `audioaudio_aac@${audioBitrate}`;
+      }
+
+      if(channelLayout) {
+        audioLadderSpec.channels = channelLayout;
+      }
     }
 
     return JSON.stringify(conf, null, 2);

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -1118,7 +1118,7 @@ exports.LoadConf = async function({name}) {
  * @return {Object} - The status response for the stream
  *
  */
-exports.StreamConfig = async function({name}) {
+exports.StreamConfig = async function({name, customSettings}) {
   let conf = await this.LoadConf({name});
   let status = {name};
 
@@ -1191,10 +1191,14 @@ exports.StreamConfig = async function({name}) {
   console.log("PROBE", probe);
   probe.format.filename = streamUrl.href;
 
-  // Create live reocording config
+  // Create live recording config
   let lc = new LiveConf(probe, node.id, endpoint, false, false, true);
 
-  const liveRecordingConfigStr = lc.generateLiveConf();
+  const liveRecordingConfigStr = lc.generateLiveConf({
+    audioBitrate: customSettings.audioBitrate,
+    audioIndex: customSettings.audioIndex,
+    partTtl: customSettings.partTtl
+  });
   let liveRecordingConfig = JSON.parse(liveRecordingConfigStr);
   console.log("CONFIG", JSON.stringify(liveRecordingConfig.live_recording));
 

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -1197,7 +1197,8 @@ exports.StreamConfig = async function({name, customSettings}) {
   const liveRecordingConfigStr = lc.generateLiveConf({
     audioBitrate: customSettings.audioBitrate,
     audioIndex: customSettings.audioIndex,
-    partTtl: customSettings.partTtl
+    partTtl: customSettings.partTtl,
+    channelLayout: customSettings.channelLayout
   });
   let liveRecordingConfig = JSON.parse(liveRecordingConfigStr);
   console.log("CONFIG", JSON.stringify(liveRecordingConfig.live_recording));

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -1218,6 +1218,14 @@ exports.StreamConfig = async function({name, customSettings}) {
     metadata: liveRecordingConfig.live_recording
   });
 
+  await this.ReplaceMetadata({
+    libraryId,
+    objectId: conf.objectId,
+    writeToken,
+    metadataSubtree: "probe",
+    metadata: probe
+  });
+
   status.fin = await this.FinalizeContentObject({
     libraryId,
     objectId: conf.objectId,


### PR DESCRIPTION
Deep copy LiveconfTemplate to avoid object values (ladder specs in particular) from being cached from multiple times applying configuration to a stream.