### PR TITLE
Add offerId to MintingStatus result for op=nft-offer-redeem

### DIFF
--- a/src/walletClient/ClientMethods.js
+++ b/src/walletClient/ClientMethods.js
@@ -1385,7 +1385,7 @@ exports.RedeemableOfferStatus = async function({tenantId, marketplaceParams, con
       status.op === "nft-offer-redeem" &&
       Utils.EqualAddress(status.address, contractAddress) &&
       status.tokenId === (tokenId || "").toString() &&
-      status.extra && typeof status.extra[0] !== "undefined" && status.extra[0].toString() === (offerId || "").toString()
+      status.offerId === (offerId || "").toString()
     ) || { status: "none" };
   } catch(error) {
     this.Log(error, true);

--- a/src/walletClient/index.js
+++ b/src/walletClient/index.js
@@ -1316,6 +1316,10 @@ class ElvWalletClient {
           if(op === "nft-transfer") {
             confirmationId = status.extra && status.extra.trans_id;
           }
+          let offerId;
+          if(op === "nft-offer-redeem") {
+            offerId = status.op.split(":")[3];
+          }
 
           return {
             ...status,
@@ -1325,7 +1329,8 @@ class ElvWalletClient {
             confirmationId,
             op,
             address: Utils.FormatAddress(address),
-            tokenId
+            tokenId,
+            offerId,
           };
         })
         .sort((a, b) => a.ts < b.ts ? 1 : -1);


### PR DESCRIPTION
Currently, RedeemableOfferStatus will return the same response (`{ status: "unknown" }`) for 2 different states:
1) Offer redemption not started
2) Redemption pending but not completed

That's because the `extra` field doesn't exist until redemption completes, so RedeemableOfferStatus can't find the offer in the "pending" state.