### PR TITLE
Add tenant auth to elv-client-js

### DIFF
--- a/src/AuthorizationClient.js
+++ b/src/AuthorizationClient.js
@@ -1035,6 +1035,8 @@ class AuthorizationClient {
       token = multiSig;
     }
 
+    path = UrlJoin("as", path);
+    
     let res;
     res = await this.client.authClient.MakeAuthServiceRequest({
       method,
@@ -1064,6 +1066,8 @@ class AuthorizationClient {
     if (this.debug) {
       console.log(`Authorization: Bearer ${multiSig}`);
     }
+
+    path = UrlJoin("as", path);
 
     let res = {};
     res = await this.client.authClient.MakeAuthServiceRequest({

--- a/src/AuthorizationClient.js
+++ b/src/AuthorizationClient.js
@@ -1036,9 +1036,6 @@ class AuthorizationClient {
     }
 
     let res;
-
-    path = UrlJoin(this.asUrlPath, path);
-
     res = await this.client.authClient.MakeAuthServiceRequest({
       method,
       path,
@@ -1069,9 +1066,6 @@ class AuthorizationClient {
     }
 
     let res = {};
-
-    path = UrlJoin(this.asUrlPath, path);
-
     res = await this.client.authClient.MakeAuthServiceRequest({
       method,
       path,

--- a/src/AuthorizationClient.js
+++ b/src/AuthorizationClient.js
@@ -1069,12 +1069,11 @@ class AuthorizationClient {
     res = await this.client.authClient.MakeAuthServiceRequest({
       method,
       path,
-      body,
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${multiSig}`,
         ...headers,
       },
-      queryParams,
+      queryParams: { ts, ...queryParams },
     });
     return res;
 

--- a/src/AuthorizationClient.js
+++ b/src/AuthorizationClient.js
@@ -1037,7 +1037,7 @@ class AuthorizationClient {
 
     let res;
 
-    path = urljoin(this.asUrlPath, path);
+    path = UrlJoin(this.asUrlPath, path);
 
     res = await this.client.authClient.MakeAuthServiceRequest({
       method,
@@ -1070,7 +1070,7 @@ class AuthorizationClient {
 
     let res = {};
 
-    path = urljoin(this.asUrlPath, path);
+    path = UrlJoin(this.asUrlPath, path);
 
     res = await this.client.authClient.MakeAuthServiceRequest({
       method,


### PR DESCRIPTION
Adds MakeTenantAuthServiceRequest and MakeTenantPathAuthServiceRequest to elv-client-js for Tenant Auth.  
Based on code from elv-live-js.

Tested in elv-live-js by swapping local methods and issuing test commands.  For example:

```
  async PostServiceRequest({ path, body={}, headers = {}, queryParams={}, useFabricToken=false }) {
    return await this.TenantAuthServiceRequest({path, method: "POST", queryParams, body, headers, useFabricToken});
  }
```
  
  becomes

```
async PostServiceRequest({ path, body={}, headers = {}, queryParams={}, useFabricToken=false }) {
      return await this.client.authClient.MakeTenantAuthServiceRequest({path, method: "POST", queryParams, body, headers, useFabricToken});
}

```

Tenant Auth in elv-client-js will support Admin API and UI.

We will be able to centralize Tenant Auth function and remove TenantAuthServiceRequest( ) and TenantPathAuthServiceRequest( ) after further examination. 