### PR TITLE
Support qfab APIv2 commits using a simple additional check

### DIFF
--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -1123,7 +1123,8 @@ exports.LatestVersionHash = async function({objectId, versionHash}) {
 };
 
 /**
- * Retrieve the version hash of the latest version of the specified object
+ * Retrieve the version hash of the latest version of the specified object via fabric API.
+ * Requires authorization.
  *
  * @methodGroup Content Objects
  * @namedParams
@@ -1134,18 +1135,16 @@ exports.LatestVersionHash = async function({objectId, versionHash}) {
  */
 exports.LatestVersionHashV2 = async function({objectId, versionHash}) {
   if(versionHash) { objectId = this.utils.DecodeVersionHash(versionHash).objectId; }
-  const libraryId = await this.ContentObjectLibraryId({objectId});
 
   ValidateObject(objectId);
 
   let latestHash;
-  console.log("LatestVersionHashV2");
   try {
     let path = UrlJoin("q", objectId);
 
     let q = await this.utils.ResponseToJson(
       this.HttpClient.Request({
-        headers: await this.authClient.AuthorizationHeader({libraryId, objectId}),
+        headers: await this.authClient.AuthorizationHeader({objectId}),
         method: "GET",
         path: path
       })

--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -1075,7 +1075,7 @@ exports.ContentObjectVersions = async function({libraryId, objectId}) {
 };
 
 /**
- * Retrieve the version hash of the latest version of the specified object
+ * Retrieve the version hash of the latest version of the specified object from chain
  *
  * @methodGroup Content Objects
  * @namedParams
@@ -1119,6 +1119,43 @@ exports.LatestVersionHash = async function({objectId, versionHash}) {
     });
   }
 
+  return latestHash;
+};
+
+/**
+ * Retrieve the version hash of the latest version of the specified object
+ *
+ * @methodGroup Content Objects
+ * @namedParams
+ * @param {string=} objectId - ID of the object
+ * @param {string=} versionHash - Version hash of the object
+ *
+ * @returns {Promise<string>} - The latest version hash of the object
+ */
+exports.LatestVersionHashV2 = async function({objectId, versionHash}) {
+  if(versionHash) { objectId = this.utils.DecodeVersionHash(versionHash).objectId; }
+  const libraryId = await this.ContentObjectLibraryId({objectId});
+
+  ValidateObject(objectId);
+
+  let latestHash;
+  console.log("LatestVersionHashV2");
+  try {
+    let path = UrlJoin("q", objectId);
+
+    let q = await this.utils.ResponseToJson(
+      this.HttpClient.Request({
+        headers: await this.authClient.AuthorizationHeader({libraryId, objectId}),
+        method: "GET",
+        path: path
+      })
+    );
+    latestHash = q.hash;
+
+  } catch(error) {
+    console.log("ERROR", error);
+    throw Error(`Unable to determine latest version hash for ${versionHash || objectId}`);
+  }
   return latestHash;
 };
 

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -8,6 +8,7 @@ const UrlJoin = require("url-join");
 const Ethers = require("ethers");
 const Pako = require("pako");
 
+
 /*
 const LibraryContract = require("../contracts/BaseLibrary");
 const ContentContract = require("../contracts/BaseContent");
@@ -1050,16 +1051,12 @@ exports.PublishContentVersion = async function({objectId, versionHash, awaitComm
   }
 
   // APIv2 ensure the fabric API returns the correct hash
-  let tries = 20;
-  const pollingInterval = 500; // ms
   if(awaitCommitConfirmation) {
-    let confirmed = false;
+    const pollingInterval = 500; // ms
     let tries = 20;
-    while (!confirmed && tries > 0) {
+    while (tries > 0) {
       const h = await this.LatestVersionHashV2({objectId});
-      console.log("Await confirmation on fabric node:", h);
       if (h == versionHash) {
-        confirmed = true;
         this.Log(`Commit confirmed on fabric node: ${versionHash}`);
         break;
       }

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -8,7 +8,6 @@ const UrlJoin = require("url-join");
 const Ethers = require("ethers");
 const Pako = require("pako");
 
-
 /*
 const LibraryContract = require("../contracts/BaseLibrary");
 const ContentContract = require("../contracts/BaseContent");
@@ -1044,11 +1043,30 @@ exports.PublishContentVersion = async function({objectId, versionHash, awaitComm
 
       if(confirmEvent) {
         // Found confirmation
-        this.Log(`Commit confirmed: ${objectHash}`);
+        this.Log(`Commit confirmed on chain: ${objectHash}`);
         break;
       }
     }
   }
+
+  // APIv2 ensure the fabric API returns the correct hash
+  let tries = 20;
+  const pollingInterval = 500; // ms
+  if(awaitCommitConfirmation) {
+    let confirmed = false;
+    let tries = 20;
+    while (!confirmed && tries > 0) {
+      const h = await this.LatestVersionHashV2({objectId});
+      console.log("Await confirmation on fabric node:", h);
+      if (h == versionHash) {
+        confirmed = true;
+        this.Log(`Commit confirmed on fabric node: ${versionHash}`);
+        break;
+      }
+      await new Promise(resolve => setTimeout(resolve, pollingInterval));
+    }
+  }
+
 };
 
 /**


### PR DESCRIPTION
The qfab APIv2 has an SSE (server-sent event) API for commit events - that is a little harder to implement and also of course is not compatible to the current API.

I propose we add a simple additional check, to wait for the qfab API to confirm the hash, which happens shortly after the blockchain confirmation.

This way there is very little additional waiting time for commits and the client works correctly with both API v1 and v2.

Once APIv2 is deployed fully and support for APIv1 is no longer require, change to use the server-sent event watcher which reduces blockchain calls and is the most immediate.