### PR TITLE
Live stream configuration using video timebase and frame duration

### DIFF
--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -283,7 +283,7 @@ class LiveConf {
       case "24":
         seg.videoTimeBase = 1536; // Output timebase: 12288
         seg.videoFrameDurationTs = 512;
-        seg.video = calcOutputTimebase(seg.videoTimeBase) * 30;
+        seg.video = this.calcOutputTimebase(seg.videoTimeBase) * 30;
         seg.keyint = 48;
         seg.duration = "30";
         break;
@@ -418,7 +418,7 @@ class LiveConf {
       conf.live_recording.recording_config.recording_params.xc_params.video_time_base = segDurations.videoTimeBase;
 
       // Note 'source_timescale' needs to be set to the output timebase and is used by playout
-      conf.live_recording.recording_config.recording_params.source_timescale = calcOutputTimebase(segDurations.videoTimeBase);
+      conf.live_recording.recording_config.recording_params.source_timescale = this.calcOutputTimebase(segDurations.videoTimeBase);
     }
     if(segDurations.videoFrameDurationTs) {
       conf.live_recording.recording_config.recording_params.xc_params.video_frame_duration_ts = segDurations.videoFrameDurationTs;

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -209,6 +209,17 @@ class LiveConf {
     return seg;
   }
 
+ /*
+  * Calculate output timebase from the encoder (codec) timebase. The videoTimeBase parameter
+  * represents the encoder timebase. The format muxer will change it so it is greater than 10000.
+  */
+  calcOutputTimebase(codecTimebase) {
+    let outputTimebase = codecTimebase;
+    while (outputTimebase < 10000)
+      outputTimebase = outputTimebase * 2;
+    return outputTimebase;
+  }
+
   calcSegDurationMpegts({sourceTimescale}) {
     let videoStream = this.getStreamDataForCodecType("video");
     let frameRate = videoStream.frame_rate;
@@ -272,7 +283,7 @@ class LiveConf {
       case "24":
         seg.videoTimeBase = 1536; // Output timebase: 12288
         seg.videoFrameDurationTs = 512;
-        seg.video = seg.videoTimeBase * 30;
+        seg.video = calcOutputTimebase(seg.videoTimeBase) * 30;
         seg.keyint = 48;
         seg.duration = "30";
         break;
@@ -284,7 +295,7 @@ class LiveConf {
       case "30":
         seg.videoTimeBase = 960; // Output timebase: 15360
         seg.videoFrameDurationTs = 512;
-        seg.video = seg.videoTimeBase * 30;
+        seg.video = this.calcOutputTimebase(seg.videoTimeBase) * 30;
         seg.keyint = 60;
         seg.duration = "30";
         break;
@@ -296,7 +307,7 @@ class LiveConf {
       case "48":
         seg.videoTimeBase = 1536; // Output timebase: 12288
         seg.videoFrameDurationTs = 512;
-        seg.video = seg.videoTimeBase * 30;
+        seg.video = this.calcOutputTimebase(seg.videoTimeBase) * 30;
         seg.keyint = 96;
         seg.duration = "30";
         break;
@@ -308,7 +319,7 @@ class LiveConf {
       case "60":
         seg.videoTimeBase = 960; // Output timebase: 15360
         seg.videoFrameDurationTs = 512;
-        seg.video = seg.videoTimeBase * 30;
+        seg.video = this.calcOutputTimebase(seg.videoTimeBase) * 30;
         seg.keyint = 120;
         seg.duration = "30";
         break;

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -416,7 +416,9 @@ class LiveConf {
     // Optional override output timebase and frame duration (ts)
     if(segDurations.videoTimeBase) {
       conf.live_recording.recording_config.recording_params.xc_params.video_time_base = segDurations.videoTimeBase;
-      conf.live_recording.recording_config.recording_params.source_timescale = segDurations.videoTimeBase;
+
+      // Note 'source_timescale' needs to be set to the output timebase and is used by playout
+      conf.live_recording.recording_config.recording_params.source_timescale = calcOutputTimebase(segDurations.videoTimeBase);
     }
     if(segDurations.videoFrameDurationTs) {
       conf.live_recording.recording_config.recording_params.xc_params.video_frame_duration_ts = segDurations.videoFrameDurationTs;

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -282,7 +282,7 @@ class LiveConf {
     switch(frameRate) {
       case "24":
         seg.videoTimeBase = 1536; // Output timebase: 12288
-        seg.videoFrameDurationTs = 640;
+        seg.videoFrameDurationTs = 512;
         seg.video = this.calcOutputTimebase(seg.videoTimeBase) * 30;
         seg.keyint = 48;
         seg.duration = "30";
@@ -306,7 +306,7 @@ class LiveConf {
         break;
       case "48":
         seg.videoTimeBase = 1536; // Output timebase: 12288
-        seg.videoFrameDurationTs = 320;
+        seg.videoFrameDurationTs = 256;
         seg.video = this.calcOutputTimebase(seg.videoTimeBase) * 30;
         seg.keyint = 96;
         seg.duration = "30";

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -270,7 +270,9 @@ class LiveConf {
 
     switch(frameRate) {
       case "24":
-        seg.video = sourceTimescale * 30;
+        seg.videoTimeBase = 1536; // Output timebase: 12288
+        seg.videoFrameDurationTs = 512;
+        seg.video = seg.videoTimeBase * 30;
         seg.keyint = 48;
         seg.duration = "30";
         break;
@@ -280,7 +282,9 @@ class LiveConf {
         seg.duration = "30";
         break;
       case "30":
-        seg.video = sourceTimescale * 30;
+        seg.videoTimeBase = 960; // Output timebase: 15360
+        seg.videoFrameDurationTs = 512;
+        seg.video = seg.videoTimeBase * 30;
         seg.keyint = 60;
         seg.duration = "30";
         break;
@@ -290,7 +294,9 @@ class LiveConf {
         seg.duration = "30.03";
         break;
       case "48":
-        seg.video = sourceTimescale * 30;
+        seg.videoTimeBase = 1536; // Output timebase: 12288
+        seg.videoFrameDurationTs = 512;
+        seg.video = seg.videoTimeBase * 30;
         seg.keyint = 96;
         seg.duration = "30";
         break;
@@ -300,7 +306,9 @@ class LiveConf {
         seg.duration = "30";
         break;
       case "60":
-        seg.video = sourceTimescale * 30;
+        seg.videoTimeBase = 960; // Output timebase: 15360
+        seg.videoFrameDurationTs = 512;
+        seg.video = seg.videoTimeBase * 30;
         seg.keyint = 120;
         seg.duration = "30";
         break;

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -282,7 +282,7 @@ class LiveConf {
     switch(frameRate) {
       case "24":
         seg.videoTimeBase = 1536; // Output timebase: 12288
-        seg.videoFrameDurationTs = 512;
+        seg.videoFrameDurationTs = 640;
         seg.video = this.calcOutputTimebase(seg.videoTimeBase) * 30;
         seg.keyint = 48;
         seg.duration = "30";
@@ -306,7 +306,7 @@ class LiveConf {
         break;
       case "48":
         seg.videoTimeBase = 1536; // Output timebase: 12288
-        seg.videoFrameDurationTs = 512;
+        seg.videoFrameDurationTs = 320;
         seg.video = this.calcOutputTimebase(seg.videoTimeBase) * 30;
         seg.keyint = 96;
         seg.duration = "30";
@@ -318,7 +318,7 @@ class LiveConf {
         break;
       case "60":
         seg.videoTimeBase = 960; // Output timebase: 15360
-        seg.videoFrameDurationTs = 512;
+        seg.videoFrameDurationTs = 256;
         seg.video = this.calcOutputTimebase(seg.videoTimeBase) * 30;
         seg.keyint = 120;
         seg.duration = "30";

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -1322,7 +1322,7 @@ exports.StreamConfig = async function({name, customSettings={}}) {
   const hostName = userConfig.url.replace("udp://", "").replace("rtmp://", "").replace("srt://", "").split(":")[0];
   const streamUrl = new URL(userConfig.url);
 
-  console.log("Retrieving nodes...");
+  console.log("Retrieving nodes - matching", hostName);
   let nodes = await this.SpaceNodes({matchEndpoint: hostName});
   if(nodes.length < 1) {
     status.error = "No node matching stream URL " + streamUrl.href;


### PR DESCRIPTION
Live streams now support new configuration options to set the video stream timebase and frame duration (in ts units).

Adapt the live stream configurator to use these new settings where necessary.  This makes it so RTMP streams create mez recordings with regular frame durations and support copy-to-vod.

Note RTMP 29.97 and 59.94 fps don't work properly with the video timebase setting and they are left unchanged.