### PR TITLE
Add live stream support for multi audio

### DIFF
--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -146,6 +146,22 @@ class LiveConf {
     return stream;
   }
 
+  // Return all audio streams found in the probe
+  // Used by generateAudioStreamsConfig()
+  getAudioStreamsFromProbe() {
+    let audioStreams = {};
+    for(let index = 0; index < this.probeData.streams.length; index++) {
+      if(this.probeData.streams[index].codec_type == "audio") {
+        audioStreams[index] = {
+          recordingBitrate: Math.min(this.probeData.streams[index].bit_rate, 128000),
+          recordingChannels: this.probeData.streams[index].channels,
+          playoutLabel: `Audio ${index}`
+        }
+      }
+    }
+    return audioStreams;
+  }
+
   getFrameRate() {
     let videoStream = this.getStreamDataForCodecType("video");
     let frameRate = videoStream.r_frame_rate || videoStream.frame_rate;
@@ -388,17 +404,7 @@ class LiveConf {
 
     // If no audio streams specified in custom config, set up all the suitable audio streams in the probe
     if (Object.keys(audioStreams).length == 0) {
-      // TODO! For now mock stream "1"
-      audioStreams[1] = {
-        recordingBitrate: 192000,
-        recordingChannels: 2,
-        playoutLabel: `Audio 1`
-      }
-      audioStreams[2] = {
-        recordingBitrate: 192200,
-        recordingChannels: 2,
-        playoutLabel: `Audio 2`
-      }
+      audioStreams = this.getAudioStreamsFromProbe();
     }
 
     return audioStreams;

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -153,7 +153,7 @@ class LiveConf {
     for(let index = 0; index < this.probeData.streams.length; index++) {
       if(this.probeData.streams[index].codec_type == "audio") {
         audioStreams[index] = {
-          recordingBitrate: Math.min(this.probeData.streams[index].bit_rate, 128000),
+          recordingBitrate: Math.max(this.probeData.streams[index].bit_rate, 128000),
           recordingChannels: this.probeData.streams[index].channels,
           playoutLabel: `Audio ${index}`
         }
@@ -447,8 +447,8 @@ class LiveConf {
       conf.live_recording.recording_config.recording_params.xc_params.sync_audio_to_stream_id = this.syncAudioToStreamIdValue();
     }
 
-    if(customSettings.partTtl) {
-      conf.live_recording.recording_config.recording_params.part_ttl = customSettings.partTtl;
+    if(customSettings.part_ttl) {
+      conf.live_recording.recording_config.recording_params.part_ttl = customSettings.part_ttl;
     }
 
     // Fill in specifics for protocol

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -85,6 +85,7 @@ const LiveconfTemplate = {
             0
           ],
           audio_seg_duration_ts: null,
+          connection_timeout: 60,
           ecodec2: "aac",
           enc_height: null,
           enc_width: null,
@@ -437,7 +438,6 @@ class LiveConf {
     conf.live_recording.recording_config.recording_params.xc_params.sample_rate = sampleRate;
     conf.live_recording.recording_config.recording_params.xc_params.enc_height = videoStream.height;
     conf.live_recording.recording_config.recording_params.xc_params.enc_width = videoStream.width;
-    conf.live_recording.recording_config.recording_params.xc_params.connection_timeout = 60;
 
     for (let i =0; i < Object.keys(audioStreams).length; i ++) {
       conf.live_recording.recording_config.recording_params.xc_params.audio_index[i] = parseInt(Object.keys(audioStreams)[i]);

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -15,6 +15,7 @@ const LadderTemplate = {
     media_type: 1,
     representation: "videovideo_1920x1080_h264@9500000",
     stream_name: "video",
+    stream_index: 0,
     width: 1920
   },
   "720": {
@@ -24,6 +25,7 @@ const LadderTemplate = {
     media_type: 1,
     representation: "videovideo_1280x720_h264@4500000",
     stream_name: "video",
+    stream_index: 0,
     width: 1280
   },
   "540": {
@@ -33,6 +35,7 @@ const LadderTemplate = {
     media_type: 1,
     representation: "videovideo_960x540_h264@2000000",
     stream_name: "video",
+    stream_index: 0,
     width: 960
   },
   "540_low": {
@@ -42,6 +45,7 @@ const LadderTemplate = {
     media_type: 1,
     representation: "videovideo_960x540_h264@900000",
     stream_name: "video",
+    stream_index: 0,
     width: 960
   }
 };
@@ -59,16 +63,7 @@ const LiveconfTemplate = {
     recording_config: {
       recording_params: {
         description: "",
-        ladder_specs: [
-          {
-            bit_rate: 384000,
-            channels: 2,
-            codecs: "mp4a.40.2",
-            media_type: 2,
-            representation: "audioaudio_aac@384000",
-            stream_name: "audio"
-          }
-        ],
+        ladder_specs: [],
         listen: true,
         live_delay_nano: 2000000000,
         max_duration_sec: -1,
@@ -108,11 +103,22 @@ const LiveconfTemplate = {
           video_bitrate: null,
           video_seg_duration_ts: null,
           video_time_base: null,
+          video_frame_duration_ts: null,
           xc_type: 3
         }
       }
     }
   }
+};
+
+const LadderSpecAudio = {
+  bit_rate: 384000,
+  channels: 2,
+  codecs: "mp4a.40.2",
+  media_type: 2,
+  representation: "audioaudio_aac@384000",
+  stream_name: "audio",
+  stream_index: 0
 };
 
 class LiveConf {
@@ -223,7 +229,12 @@ class LiveConf {
   calcSegDurationMpegts({sourceTimescale}) {
     let videoStream = this.getStreamDataForCodecType("video");
     let frameRate = videoStream.frame_rate;
-    let seg = {};
+
+    // PENDING(SS) - calculate frame duration here
+    // let frameRateNum = 0;
+    let seg = {
+      //  videoFrameDurationTs: sourceTimescale / frameRateNum
+    };
 
     switch(frameRate) {
       case "24":
@@ -242,21 +253,25 @@ class LiveConf {
         seg.duration = "30";
         break;
       case "30000/1001":
+        //seg.videoFrameDurationTs = 3003;
         seg.video = sourceTimescale * 30;
         seg.keyint = 60;
         seg.duration = "30.03";
         break;
       case "48":
+        //seg.videoFrameDurationTs = 1875;
         seg.video = sourceTimescale * 30;
         seg.keyint = 96;
         seg.duration = "30";
         break;
       case "50":
+        //seg.videoFrameDurationTs = 1800;
         seg.video = sourceTimescale * 30;
         seg.keyint = 100;
         seg.duration = "30";
         break;
       case "60":
+        //seg.videoFrameDurationTs = 1500;
         seg.video = sourceTimescale * 30;
         seg.keyint = 120;
         seg.duration = "30";
@@ -281,7 +296,7 @@ class LiveConf {
 
     switch(frameRate) {
       case "24":
-        seg.videoTimeBase = 1536; // Output timebase: 12288
+        seg.videoTimeBase = 768; // Note 1536 produces low output bitrate
         seg.videoFrameDurationTs = 512;
         seg.video = this.calcOutputTimebase(seg.videoTimeBase) * 30;
         seg.keyint = 48;
@@ -350,11 +365,52 @@ class LiveConf {
     return sync_id;
   }
 
-  generateLiveConf({audioBitrate, audioIndex, partTtl, channelLayout}) {
+ /*
+  * Generate audio streams recording configuration based on the optional custom settings.
+  * If no custom "audio" section is present, record all the acceptable audio streams found in the probe
+  */
+  generateAudioStreamsConfig({customSettings}) {
+
+    let audioStreams = {};
+    if (customSettings && customSettings.audio) {
+      for (let i = 0; i < Object.keys(customSettings.audio).length; i ++) {
+        let audio = customSettings.audio[i];
+        audioStreams[i] = {
+          recordingBitrate: audio.recording_bitrate || 192000,
+          recordingChannels: audio.recording_channels || 2,
+        };
+        if (audio.playout) {
+          audioStreams[i].playoutLabel = audio.playout_label || `Audio ${i}`
+        }
+      }
+    }
+
+    // If no audio streams specified in custom config, set up all the suitable audio streams in the probe
+    if (Object.keys(audioStreams).length == 0) {
+      // TODO! For now mock stream "1"
+      audioStreams[1] = {
+        recordingBitrate: 192000,
+        recordingChannels: 2,
+        playoutLabel: `Audio 1`
+      }
+      audioStreams[2] = {
+        recordingBitrate: 192200,
+        recordingChannels: 2,
+        playoutLabel: `Audio 2`
+      }
+    }
+
+    return audioStreams;
+  }
+
+ /*
+  * Generate the live recording config as required by QFAB, based on defaults and optional custom settings.
+  */
+  generateLiveConf({customSettings}) {
     // gather required data
     const conf = JSON.parse(JSON.stringify(LiveconfTemplate));
     const fileName = this.overwriteOriginUrl || this.probeData.format.filename;
-    const audioStream = this.getStreamDataForCodecType("audio");
+    const audioStreams = this.generateAudioStreamsConfig({customSettings})
 
     const sampleRate = parseInt(audioStream.sample_rate);
     const audioCodec = audioStream.codec_name;
@@ -369,17 +425,20 @@ class LiveConf {
     conf.live_recording.recording_config.recording_params.origin_url = fileName;
     conf.live_recording.recording_config.recording_params.description = `Ingest stream ${fileName}`;
     conf.live_recording.recording_config.recording_params.name = `Ingest stream ${fileName}`;
-    conf.live_recording.recording_config.recording_params.xc_params.audio_index[0] = audioIndex === undefined ? audioStream.stream_index : audioIndex;
     conf.live_recording.recording_config.recording_params.xc_params.sample_rate = sampleRate;
     conf.live_recording.recording_config.recording_params.xc_params.enc_height = videoStream.height;
     conf.live_recording.recording_config.recording_params.xc_params.enc_width = videoStream.width;
+
+    for (let i =0; i < Object.keys(audioStreams).length; i ++) {
+      conf.live_recording.recording_config.recording_params.xc_params.audio_index[i] = parseInt(Object.keys(audioStreams)[i]);
+    }
 
     if(this.syncAudioToVideo) {
       conf.live_recording.recording_config.recording_params.xc_params.sync_audio_to_stream_id = this.syncAudioToStreamIdValue();
     }
 
-    if(partTtl) {
-      conf.live_recording.recording_config.recording_params.part_ttl = partTtl;
+    if(customSettings.partTtl) {
+      conf.live_recording.recording_config.recording_params.part_ttl = customSettings.partTtl;
     }
 
     // Fill in specifics for protocol
@@ -472,21 +531,33 @@ class LiveConf {
         throw new Error("ERROR: Probed stream does not conform to one of the following built in resolution ladders [4096, 2160], [1920, 1080] [1280, 720], [960, 540]");
     }
 
-    if(audioBitrate || channelLayout) {
-      const audioLadderSpec = conf.live_recording.recording_config.recording_params.ladder_specs.find(spec => spec.stream_name === "audio");
 
-      if(audioBitrate) {
-        conf.live_recording.recording_config.recording_params.xc_params.audio_bitrate = audioBitrate;
-        audioLadderSpec.bit_rate = audioBitrate;
-        audioLadderSpec.representation = `audioaudio_aac@${audioBitrate}`;
-      }
+    let globalAudioBitrate = 0;
+    let nAudio = 0;
 
-      if(channelLayout) {
-        audioLadderSpec.channels = channelLayout;
+    for (let i = 0; i < Object.keys(audioStreams).length; i ++ ) {
+      let audioLadderSpec = {...LadderSpecAudio};
+      const audioIndex = Object.keys(audioStreams)[i];
+      const audio = audioStreams[audioIndex];
+      audioLadderSpec.bit_rate = audio.recordingBitrate;
+      audioLadderSpec.representation = `audioaudio_aac@${audio.recordingBitrate}`;
+      audioLadderSpec.channels = audio.recordingChannels;
+      audioLadderSpec.stream_index = parseInt(audioIndex);
+      audioLadderSpec.stream_name = `audio_${audioIndex}`;
+      audioLadderSpec.stream_label = audio.playoutLabel ? audio.playoutLabel : null;
+
+      conf.live_recording.recording_config.recording_params.ladder_specs.push(audioLadderSpec);
+      if (audio.recordingBitrate > globalAudioBitrate) {
+        globalAudioBitrate = audio.recordingBitrate;
       }
+      nAudio ++;
     }
 
-    return JSON.stringify(conf, null, 2);
+    // Global recording bitrate for all audio streams
+    conf.live_recording.recording_config.recording_params.xc_params.audio_bitrate = globalAudioBitrate;
+    conf.live_recording.recording_config.recording_params.xc_params.n_audio = nAudio;
+
+    return conf;
   }
 }
 exports.LiveConf = LiveConf;

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -428,7 +428,6 @@ class LiveConf {
     let sourceTimescale;
 
     // Fill in liveconf all formats have in common
-    conf.live_recording.probe_info = this.probeData;
     conf.live_recording.fabric_config.ingress_node_api = this.nodeUrl || null;
     conf.live_recording.fabric_config.ingress_node_id = this.nodeId || null;
     conf.live_recording.recording_config.recording_params.description;
@@ -445,6 +444,10 @@ class LiveConf {
 
     if(this.syncAudioToVideo) {
       conf.live_recording.recording_config.recording_params.xc_params.sync_audio_to_stream_id = this.syncAudioToStreamIdValue();
+    }
+
+    if(customSettings.edge_write_token) {
+      conf.live_recording.fabric_config.edge_write_token = customSettings.edge_write_token;
     }
 
     if(customSettings.part_ttl) {

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -410,10 +410,13 @@ class LiveConf {
     // gather required data
     const conf = JSON.parse(JSON.stringify(LiveconfTemplate));
     const fileName = this.overwriteOriginUrl || this.probeData.format.filename;
-    const audioStreams = this.generateAudioStreamsConfig({customSettings})
+    const audioStreams = this.generateAudioStreamsConfig({customSettings});
 
+    // Retrieve one audio stream from the probe to read the sample rate and codec name
+    const audioStream = this.getStreamDataForCodecType("audio");
     const sampleRate = parseInt(audioStream.sample_rate);
     const audioCodec = audioStream.codec_name;
+
     const videoStream = this.getStreamDataForCodecType("video");
     let sourceTimescale;
 

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -374,13 +374,14 @@ class LiveConf {
     let audioStreams = {};
     if (customSettings && customSettings.audio) {
       for (let i = 0; i < Object.keys(customSettings.audio).length; i ++) {
-        let audio = customSettings.audio[i];
-        audioStreams[i] = {
+        let audioIdx = Object.keys(customSettings.audio)[i];
+        let audio = customSettings.audio[audioIdx];
+        audioStreams[audioIdx] = {
           recordingBitrate: audio.recording_bitrate || 192000,
           recordingChannels: audio.recording_channels || 2,
         };
         if (audio.playout) {
-          audioStreams[i].playoutLabel = audio.playout_label || `Audio ${i}`
+          audioStreams[audioIdx].playoutLabel = audio.playout_label || `Audio ${audioIdx}`
         }
       }
     }

--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -437,6 +437,7 @@ class LiveConf {
     conf.live_recording.recording_config.recording_params.xc_params.sample_rate = sampleRate;
     conf.live_recording.recording_config.recording_params.xc_params.enc_height = videoStream.height;
     conf.live_recording.recording_config.recording_params.xc_params.enc_width = videoStream.width;
+    conf.live_recording.recording_config.recording_params.xc_params.connection_timeout = 60;
 
     for (let i =0; i < Object.keys(audioStreams).length; i ++) {
       conf.live_recording.recording_config.recording_params.xc_params.audio_index[i] = parseInt(Object.keys(audioStreams)[i]);

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -1421,8 +1421,24 @@ exports.StreamConfig = async function({name, customSettings={}, probeMetadata}) 
     libraryId,
     objectId,
     writeToken,
-    metadataSubtree: "live_recording",
-    metadata: liveRecordingConfig.live_recording
+    metadataSubtree: "live_recording/fabric_config",
+    metadata: liveRecordingConfig.live_recording.fabric_config
+  });
+
+  await this.ReplaceMetadata({
+    libraryId,
+    objectId,
+    writeToken,
+    metadataSubtree: "live_recording/probe_info",
+    metadata: liveRecordingConfig.live_recording.probe_info
+  });
+
+  await this.ReplaceMetadata({
+    libraryId,
+    objectId,
+    writeToken,
+    metadataSubtree: "live_recording/recording_config",
+    metadata: liveRecordingConfig.live_recording.recording_config
   });
 
   status.fin = await this.FinalizeContentObject({

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -623,7 +623,7 @@ exports.StreamStatus = async function({name, stopLro=false, showParams=false}) {
 */
 exports.StreamCreate = async function({name, start=false}) {
   let status = await this.StreamStatus({name});
-  if(status.state !== "inactive" && status.state !== "terminated" && status.state !== "stopped") {
+  if(status.state != "uninitialized" && status.state !== "inactive" && status.state !== "terminated" && status.state !== "stopped") {
     return {
       state: status.state,
       error: "stream still active - must terminate first"
@@ -981,7 +981,7 @@ exports.StreamInitialize = async function({name, drm=false, format}) {
  */
 exports.StreamSetOfferingAndDRM = async function({name, typeAbrMaster, typeLiveStream, drm=false, format}) {
   let status = await this.StreamStatus({name});
-  if(status.state != "inactive" && status.state != "stopped") {
+  if(status.state != "uninitialized" && status.state != "inactive" && status.state != "stopped") {
     return {
       state: status.state,
       error: "stream still active - must terminate first"

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -1417,36 +1417,20 @@ exports.StreamConfig = async function({name, customSettings={}, probeMetadata}) 
   });
   let writeToken = e.write_token;
 
-  await this.MergeMetadata({
+  await this.ReplaceMetadata({
     libraryId,
     objectId,
     writeToken,
-    metadataSubtree: "live_recording/fabric_config",
-    metadata: liveRecordingConfig.live_recording.fabric_config
+    metadataSubtree: "live_recording",
+    metadata: liveRecordingConfig.live_recording
   });
 
   await this.ReplaceMetadata({
     libraryId,
     objectId,
     writeToken,
-    metadataSubtree: "live_recording/playout_config",
-    metadata: liveRecordingConfig.live_recording.playout_config
-  });
-
-  await this.MergeMetadata({
-    libraryId,
-    objectId,
-    writeToken,
-    metadataSubtree: "live_recording/probe_info",
-    metadata: liveRecordingConfig.live_recording.probe_info
-  });
-
-  await this.ReplaceMetadata({
-    libraryId,
-    objectId,
-    writeToken,
-    metadataSubtree: "live_recording/recording_config",
-    metadata: liveRecordingConfig.live_recording.recording_config
+    metadataSubtree: "live_recording_config/probe_info",
+    metadata: probe
   });
 
   status.fin = await this.FinalizeContentObject({
@@ -1499,7 +1483,8 @@ exports.StreamListUrls = async function({siteId}={}) {
       objectId: siteId,
       metadataSubtree: "public/asset_metadata/live_streams",
       resolveLinks: true,
-      resolveIgnoreErrors: true
+      resolveIgnoreErrors: true,
+      resolveIncludeSource: true
     });
 
     const activeUrlMap = {};
@@ -1510,18 +1495,8 @@ exports.StreamListUrls = async function({siteId}={}) {
         const stream = streamMetadata[slug];
         let versionHash;
 
-        if(
-          stream &&
-          stream.sources &&
-          stream.sources.default &&
-          stream.sources.default["."] &&
-          stream.sources.default["."].container ||
-          ((stream["/"] || "").match(/^\/?qfab\/([\w]+)\/?.+/) || [])[1]
-        ) {
-          versionHash = (
-            stream.sources.default["."].container ||
-            ((stream["/"] || "").match(/^\/?qfab\/([\w]+)\/?.+/) || [])[1]
-          );
+        if(stream && stream["."] && stream["."].source) {
+          versionHash = stream["."].source;
         }
 
         if(versionHash) {

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -890,8 +890,7 @@ exports.StreamStopSession = async function({name}) {
         fabric_config: {
           edge_write_token: ""
         }
-      },
-      recording_stop_time: stopTime
+      }
     };
 
     await this.MergeMetadata({

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -1417,7 +1417,7 @@ exports.StreamConfig = async function({name, customSettings={}, probeMetadata}) 
   });
   let writeToken = e.write_token;
 
-  await this.ReplaceMetadata({
+  await this.MergeMetadata({
     libraryId,
     objectId,
     writeToken,

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -445,7 +445,7 @@ exports.StreamStatus = async function({name, stopLro=false, showParams=false}) {
     let videoLastFinalizationTimeEpochSec = -1;
     let videoFinalizedParts = 0;
     let sinceLastFinalize = -1;
-    if (period.finalized_parts_info.video && period.finalized_parts_info.video.last_finalization_time) {
+    if (period.finalized_parts_info && period.finalized_parts_info.video && period.finalized_parts_info.video.last_finalization_time) {
       videoLastFinalizationTimeEpochSec = period.finalized_parts_info.video.last_finalization_time / 1000000;
       videoFinalizedParts = period.finalized_parts_info.video.n_parts;
       sinceLastFinalize = Math.floor(new Date().getTime() / 1000) - videoLastFinalizationTimeEpochSec;

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -1429,6 +1429,14 @@ exports.StreamConfig = async function({name, customSettings={}, probeMetadata}) 
     libraryId,
     objectId,
     writeToken,
+    metadataSubtree: "live_recording/playout_config",
+    metadata: liveRecordingConfig.live_recording.playout_config
+  });
+
+  await this.MergeMetadata({
+    libraryId,
+    objectId,
+    writeToken,
     metadataSubtree: "live_recording/probe_info",
     metadata: liveRecordingConfig.live_recording.probe_info
   });

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -358,17 +358,17 @@ const StreamGenerateOffering = async({
  * @return {Promise<Object>} - The status response for the object, as well as logs, warnings and errors from the master initialization
  */
 exports.StreamStatus = async function({name, stopLro=false, showParams=false}) {
-  let conf = await this.LoadConf({name});
+  let objectId = name;
   let status = {name: name};
 
   try {
-    let libraryId = await this.ContentObjectLibraryId({objectId: conf.objectId});
+    let libraryId = await this.ContentObjectLibraryId({objectId});
     status.library_id = libraryId;
-    status.object_id = conf.objectId;
+    status.object_id = objectId;
 
     let mainMeta = await this.ContentObjectMetadata({
-      libraryId: libraryId,
-      objectId: conf.objectId,
+      libraryId,
+      objectId,
       select: [
         "live_recording_config",
         "live_recording"
@@ -416,7 +416,7 @@ exports.StreamStatus = async function({name, stopLro=false, showParams=false}) {
     status.stream_id = edgeWriteToken; // By convention the stream ID is its write token
     let edgeMeta = await this.ContentObjectMetadata({
       libraryId: libraryId,
-      objectId: conf.objectId,
+      objectId: objectId,
       writeToken: edgeWriteToken,
       select: [
         "live_recording"
@@ -465,7 +465,7 @@ exports.StreamStatus = async function({name, stopLro=false, showParams=false}) {
 
     status.lro_status_url = await this.FabricUrl({
       libraryId: libraryId,
-      objectId: conf.objectId,
+      objectId: objectId,
       writeToken: edgeWriteToken,
       call: "live/status/" + tlro
     });
@@ -516,8 +516,8 @@ exports.StreamStatus = async function({name, stopLro=false, showParams=false}) {
 
     if((state === "running" || state === "stalled" || state === "starting") && stopLro) {
       lroStopUrl = await this.FabricUrl({
-        libraryId: libraryId,
-        objectId: conf.objectId,
+        libraryId,
+        objectId,
         writeToken: edgeWriteToken,
         call: "live/stop/" + tlro
       });
@@ -538,7 +538,6 @@ exports.StreamStatus = async function({name, stopLro=false, showParams=false}) {
 
     if(state === "running") {
       let playout_urls = {};
-      let objectId = conf.objectId;
       let playout_options = await this.PlayoutOptions({
         objectId,
         linkPath: "public/asset_metadata/sources/default"
@@ -599,7 +598,7 @@ exports.StreamStatus = async function({name, stopLro=false, showParams=false}) {
       if(networkInfo.name.includes("demo")) {
         embed_net = "demo";
       }
-      let embed_url = `https://embed.v3.contentfabric.io/?net=${embed_net}&p&ct=h&oid=${conf.objectId}&mt=lv&ath=${token}`;
+      let embed_url = `https://embed.v3.contentfabric.io/?net=${embed_net}&p&ct=h&oid=${objectId}&mt=lv&ath=${token}`;
       playout_urls.embed_url = embed_url;
 
       status.playout_urls = playout_urls;
@@ -734,7 +733,7 @@ exports.StreamCreate = async function({name, start=false}) {
 */
 exports.StreamStartOrStopOrReset = async function({name, op}) {
   try {
-    let status = await this.StreamStatus({name});
+    let status = await this.StreamStatus({name})
     if(status.state != "stopped") {
       if(op === "start") {
         status.error = "Unable to start stream - state: " + status.state;
@@ -939,9 +938,8 @@ exports.StreamInitialize = async function({name, drm=false, format}) {
   let typeLiveStream;
 
   // Fetch Title and Live Stream content types from tenant meta
-  const tenantContractId = await client.userProfileClient.TenantContractId();
-  let liveStreamContentType, titleContentType;
-  const {live_stream, title} = await client.ContentObjectMetadata({
+  const tenantContractId = await this.userProfileClient.TenantContractId();
+  const {live_stream, title} = await this.ContentObjectMetadata({
     libraryId: tenantContractId.replace("iten", "ilib"),
     objectId: tenantContractId.replace("iten", "iq__"),
     metadataSubtree: "public/content_types",
@@ -970,7 +968,7 @@ exports.StreamInitialize = async function({name, drm=false, format}) {
 };
 
 /**
- * Set the Live Stream offering
+ * Create a dummy VoD offering and initialize DRM keys.
  *
  * @methodGroup Live Stream
  * @namedParams
@@ -1168,13 +1166,12 @@ exports.StreamInsertion = async function({name, insertionTime, sinceStart=false,
     }
   }
 
-  let conf = await this.LoadConf({name});
-  let libraryId = await this.ContentObjectLibraryId({objectId: conf.objectId});
-  let objectId = conf.objectId;
+  let objectId = name;
+  let libraryId = await this.ContentObjectLibraryId({objectId});
 
   let mainMeta = await this.ContentObjectMetadata({
-    libraryId: libraryId,
-    objectId: conf.objectId
+    libraryId,
+    objectId
   });
 
   let fabURI = mainMeta.live_recording.fabric_config.ingress_node_api;
@@ -1188,8 +1185,8 @@ exports.StreamInsertion = async function({name, insertionTime, sinceStart=false,
   let edgeWriteToken = mainMeta.live_recording.fabric_config.edge_write_token;
 
   let edgeMeta = await this.ContentObjectMetadata({
-    libraryId: libraryId,
-    objectId: conf.objectId,
+    libraryId,
+    objectId,
     writeToken: edgeWriteToken
   });
 
@@ -1304,43 +1301,6 @@ exports.StreamInsertion = async function({name, insertionTime, sinceStart=false,
 };
 
 /**
- * Load cached stream configuration
- *
- * @methodGroup Live Stream
- * @namedParams
- * @param {string} name - Object ID or name of the live stream object
- *
- * @return {Promise<Object>} - The configuration of the stream
- */
-exports.LoadConf = async function({name}) {
-  if(name.startsWith("iq__")) {
-    return {
-      name: name,
-      objectId: name
-    };
-  }
-
-  // If name is not a QID, load liveconf.json
-  let streamsBuf;
-  try {
-    streamsBuf = fs.readFileSync(
-      path.resolve(__dirname, "../liveconf.json")
-    );
-  } catch(error) {
-    console.log("Stream name must be a QID or a label in liveconf.json");
-    return {};
-  }
-  const streams = JSON.parse(streamsBuf);
-  const conf = streams[name];
-  if(conf === null) {
-    console.log("Bad name: ", name);
-    return {};
-  }
-
-  return conf;
-};
-
-/**
  * Configure the stream
  *
  * @methodGroup Live Stream
@@ -1356,16 +1316,16 @@ exports.LoadConf = async function({name}) {
  *
  */
 exports.StreamConfig = async function({name, customSettings={}}) {
-  let conf = await this.LoadConf({name});
+  let objectId = name;
   let status = {name};
 
-  let libraryId = await this.ContentObjectLibraryId({objectId: conf.objectId});
+  let libraryId = await this.ContentObjectLibraryId({objectId});
   status.library_id = libraryId;
-  status.object_id = conf.objectId;
+  status.object_id = objectId;
 
   let mainMeta = await this.ContentObjectMetadata({
     libraryId: libraryId,
-    objectId: conf.objectId
+    objectId: objectId
   });
 
   let userConfig = mainMeta.live_recording_config;
@@ -1398,7 +1358,7 @@ exports.StreamConfig = async function({name, customSettings={}}) {
 
     let probeUrl = await this.Rep({
       libraryId,
-      objectId: conf.objectId,
+      objectId,
       rep: "probe"
     });
 
@@ -1438,18 +1398,17 @@ exports.StreamConfig = async function({name, customSettings={}}) {
     channelLayout: customSettings.channelLayout
   });
   let liveRecordingConfig = JSON.parse(liveRecordingConfigStr);
-  console.log("CONFIG", JSON.stringify(liveRecordingConfig.live_recording));
 
   // Store live recording config into the stream object
   let e = await this.EditContentObject({
     libraryId,
-    objectId: conf.objectId
+    objectId: objectId
   });
   let writeToken = e.write_token;
 
   await this.ReplaceMetadata({
     libraryId,
-    objectId: conf.objectId,
+    objectId,
     writeToken,
     metadataSubtree: "live_recording",
     metadata: liveRecordingConfig.live_recording
@@ -1457,7 +1416,7 @@ exports.StreamConfig = async function({name, customSettings={}}) {
 
   status.fin = await this.FinalizeContentObject({
     libraryId,
-    objectId: conf.objectId,
+    objectId,
     writeToken,
     commitMessage: "Apply live stream configuration"
   });
@@ -1652,7 +1611,7 @@ exports.StreamCopyToVod = async function({
   startTime="",
   endTime=""
 }) {
-  const conf = await this.LoadConf({name});
+  const objectId = name;
   const abrProfile = require("../abr_profiles/abr_profile_live_to_vod.js");
 
   const status = await this.StreamStatus({name});
@@ -1678,9 +1637,9 @@ exports.StreamCopyToVod = async function({
   }
 
   try {
-    status.live_object_id = conf.objectId;
+    status.live_object_id = objectId;
 
-    const liveHash = await this.LatestVersionHash({objectId: conf.objectId, libraryId});
+    const liveHash = await this.LatestVersionHash({objectId, libraryId});
     status.live_hash = liveHash;
 
     if(eventId) {


### PR DESCRIPTION
To support multiple audio streams, live_recording metadata changed and is not backward compatible.

Add support for a new configuration structure:

```json
{
       "audio" {
        "1" : {  // This is the stream index
          "tags" : "language: english",
          "codec" : "aac",
          "bitrate": 204000,
          "record":  true,
          "recording_bitrate" : 192000,
          "recording_channels" : 2,
          "playout": true,
          "playout_label": "English (Stereo)"
        },
        "3": {
          ...
        }
      }
 }
```