### PR TITLE
add wait for tx receipt in elv-client-js tests

### DIFF
--- a/test/utils/Utils.js
+++ b/test/utils/Utils.js
@@ -58,11 +58,11 @@ const CreateClient = async (name, bux="2") => {
     // Each test file is run in parallel, so there may be collisions when initializing - retry until success
     for(let i = 0; i < 5; i++) {
       try {
-        await fundedSigner.sendTransaction({
+        let receipt = await fundedSigner.sendTransaction({
           to: signer.address,
           value: Ethers.utils.parseEther(bux)
         });
-
+        await receipt.wait();
         break;
       } catch(e) {
         await new Promise(resolve => setTimeout(resolve, 1000));


### PR DESCRIPTION
required when we update the mining of the blocks to 3s.