### PR TITLE
update to TestConfiguration file

### DIFF
--- a/test/ElvClient.test.js
+++ b/test/ElvClient.test.js
@@ -1,4 +1,4 @@
-const {Initialize} = require("./utils/Utils");
+const {Initialize, SetNodes} = require("./utils/Utils");
 const fs = require("fs");
 const Path = require("path");
 const {
@@ -170,6 +170,7 @@ describe("Test ElvClient", () => {
   describe("Initialize From Configuration Url", () => {
     test("Initialization", async () => {
       const bootstrapClient = await ElvClient.FromConfigurationUrl({configUrl});
+      SetNodes(bootstrapClient);
 
       expect(bootstrapClient).toBeDefined();
       expect(bootstrapClient.fabricURIs).toBeDefined();
@@ -181,6 +182,7 @@ describe("Test ElvClient", () => {
 
     test("Initialization With Region", async () => {
       const bootstrapClient = await ElvClient.FromConfigurationUrl({configUrl, region: "eu-west"});
+      SetNodes(bootstrapClient);
 
       expect(bootstrapClient).toBeDefined();
       expect(bootstrapClient.fabricURIs).toBeDefined();

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -1,4 +1,4 @@
-const {Initialize} = require("./utils/Utils");
+const {Initialize,SetNodes} = require("./utils/Utils");
 const OutputLogger = require("./utils/OutputLogger");
 const {
   describe,
@@ -23,6 +23,7 @@ describe("Test Utils", () => {
     globalThis.window = undefined;
 
     const client = await ElvClient.FromConfigurationUrl({configUrl});
+    SetNodes(client);
 
     expect(client.utils).toBeDefined();
 

--- a/test/utils/Utils.js
+++ b/test/utils/Utils.js
@@ -6,8 +6,8 @@ const ClientConfiguration = require("../../TestConfiguration");
 const ElvCrypto = require("../../src/Crypto");
 
 const configUrl = process.env["CONFIG_URL"] || ClientConfiguration["config-url"];
-const fabricUrl = process.env["FABRIC_URL"] || ClientConfiguration["fabric_url"] || "";
-const ethUrl = process.env["ETH_URL"] || ClientConfiguration["eth_url"] || "";
+const fabricUrl = process.env["FABRIC_URL"] || ClientConfiguration["fabric-url"] || "";
+const ethUrl = process.env["ETH_URL"] || ClientConfiguration["eth-url"] || "";
 
 // Uses source by default. If USE_BUILD is specified, uses the minified node version
 //const ElvClient = process.env["USE_BUILD"] ? Min.ElvClient : Source.ElvClient;

--- a/test/utils/Utils.js
+++ b/test/utils/Utils.js
@@ -6,6 +6,8 @@ const ClientConfiguration = require("../../TestConfiguration");
 const ElvCrypto = require("../../src/Crypto");
 
 const configUrl = process.env["CONFIG_URL"] || ClientConfiguration["config-url"];
+const fabricUrl = process.env["FABRIC_URL"] || ClientConfiguration["fabric_url"] || "";
+const ethUrl = process.env["ETH_URL"] || ClientConfiguration["eth_url"] || "";
 
 // Uses source by default. If USE_BUILD is specified, uses the minified node version
 //const ElvClient = process.env["USE_BUILD"] ? Min.ElvClient : Source.ElvClient;
@@ -32,6 +34,32 @@ const RandomString = (size) => {
   return crypto.randomBytes(size).toString("hex");
 };
 
+const SetNodes = (client) => {
+  if(fabricUrl !== "") {
+    client.SetNodes({
+      fabricURIs: [fabricUrl],
+    });
+
+    const nodes = client.Nodes();
+    if(nodes.fabricURIs[0] !== fabricUrl) {
+      throw Error("fabric_url is not being set to the provided values");
+    }
+  }
+
+  if(ethUrl !== "") {
+    client.SetNodes({
+      ethereumURIs: [ethUrl],
+    });
+
+    const nodes = client.Nodes();
+    if(nodes.ethereumURIs[0] !== ethUrl) {
+      throw Error("eth_url is not being set to the provided values");
+    }
+  }
+
+  console.log("client nodes:", client.Nodes());
+};
+
 const CreateClient = async (name, bux="2") => {
   try {
     // Un-initialize global.window so that elv-crypto knows it's running in node
@@ -39,7 +67,10 @@ const CreateClient = async (name, bux="2") => {
     globalThis.window = undefined;
 
     const fundedClient = await ElvClient.FromConfigurationUrl({configUrl});
+    SetNodes(fundedClient);
+
     const client = await ElvClient.FromConfigurationUrl({configUrl});
+    SetNodes(client);
 
     const wallet = client.GenerateWallet();
     const fundedSigner = wallet.AddAccount({privateKey});
@@ -130,5 +161,6 @@ module.exports = {
   RandomBytes,
   RandomString,
   CreateClient,
-  ReturnBalance
+  ReturnBalance,
+  SetNodes
 };


### PR DESCRIPTION
In order to test against particular fabric or ethereum url, we can specify it in `TestConfiguration.json` file  as shown below or as environment variables `FABRIC_URL` and `ETH_URL`.

Example TestConfiguration.json file:
```
{
  "config-url": "https://demov3.net955210.contentfabric.io/config",
  "eth-url": "https://host-76-74-28-234.contentfabric.io/eth/",
  "fabric-url": "http://dev-001.dv3.local:8008"
}
```

Initially, it reads all the data from the standard `config-url`. If FABRIC_URL and ETH_URL are set, it updates the node details accordingly. In above example, it reads data from the demov3 network and updates the Fabric and Ethereum nodes to the provided values.