### PR TITLE
Misc changes - add 'local' network name, ElvClient.Networks() method, update doc link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -280,7 +280,7 @@ const libraryObjectId = client.utils.AddressToObjectId(libraryAddress);
 <p>See the <a href="https://github.com/eluv-io/elv-stream-sample">Stream Sample App</a> for a detailed explanation on playing video from the Fabric using the Eluvio JavaScript client.</p>
 <p><a name="abr-publishing"></a></p>
 <h2>Publishing ABR Video Content on the Fabric</h2>
-<p>For more information on how to publish ABR content see <a href="https://eluv-io.github.io/elv-client-js/abr/index.html">this detailed guide</a>.</p>
+<p>For more information on how to publish ABR content see <a href="https://docs.eluv.io/docs/guides/media-ingest/">this detailed guide</a>.</p>
 <p><a name="resources"></a></p>
 <h2>Other Resources</h2>
 <p>Our Core, Fabric Browser and Video Editor apps are all completely open source, and make extensive use of this client:</p>

--- a/src/ElvClient.js
+++ b/src/ElvClient.js
@@ -26,6 +26,7 @@ const networks = {
   "main": "https://main.net955305.contentfabric.io",
   "demo": "https://demov3.net955210.contentfabric.io",
   "demov3": "https://demov3.net955210.contentfabric.io",
+  "local": "http://127.0.0.1:8008/config?qspace=dev&self",
   "test": "https://test.net955203.contentfabric.io"
 };
 
@@ -272,6 +273,17 @@ class ElvClient {
 
       throw error;
     }
+  }
+
+  /**
+   * Return a list of valid Eluvio Content Fabric network names and their associated configuration URLs
+   *
+   * @methodGroup Miscellaneous
+   *
+   * @return {Object} - An object using network names as keys and configuration URLs as values.
+   */
+  static Networks() {
+    return networks;
   }
 
   /**


### PR DESCRIPTION
 * Add support for `"local"` to `ElvClient.FromNetworkName()` (allows tests to use `FromNetworkName()` and easily switch between testing against local dev node and deployed content fabric)
 * Make network names / config URLs available via new method `ElvClient.Networks()` (allows earlier input validation by scripts)
 * Update media ingest documentation link to latest URL