### PR TITLE
Replace SpaceNodes logic with /nodes and /nodes/:id api's

### DIFF
--- a/src/ElvClient.js
+++ b/src/ElvClient.js
@@ -574,7 +574,7 @@ class ElvClient {
    * @param {string=} matchEndpoint - Return node(s) matching the specified endpoint
    * @param {string=} matchNodeId - Return node(s) matching the specified node ID
    *
-   * @return {Array<Object>} - A list of nodes in the space matching the parameters
+   * @return {Promise<Array<Object>>} - A list of nodes in the space matching the parameters
    */
   async SpaceNodes({matchEndpoint, matchNodeId}={}) {
     let nodes;

--- a/src/ElvClient.js
+++ b/src/ElvClient.js
@@ -601,15 +601,20 @@ class ElvClient {
         if(
           node.services &&
           node.services.fabric_api &&
-          node.services.fabric_api.urls &&
-          (node.services.fabric_api.urls || []).includes(matchEndpoint)
+          node.services.fabric_api.urls
         ) {
-          match = true;
+          const results = (node.services.fabric_api.urls || []).find(url => url.includes(matchEndpoint));
+
+          if(results) {
+            match = true;
+          }
         }
 
         if(matchNodeId && node.id === matchNodeId) {
           match = true;
         }
+
+        this.ClearStaticToken();
 
         return match;
       });
@@ -625,6 +630,7 @@ class ElvClient {
         })
       );
 
+      this.ClearStaticToken();
       return [node];
     }
   }

--- a/src/ElvClient.js
+++ b/src/ElvClient.js
@@ -20,7 +20,7 @@ const Pako = require("pako");
 const {
   ValidatePresence
 } = require("./Validation");
-const CBOR = require("cbor-x");
+const UrlJoin = require("url-join");
 
 const networks = {
   "main": "https://main.net955305.contentfabric.io",
@@ -134,7 +134,7 @@ class ElvClient {
    * @param {Array<string>=} searchURIs - A list of full URIs to search service endpoints
    * @param {number=} ethereumContractTimeout=10 - Number of seconds to wait for contract calls
    * @param {string=} trustAuthorityId - (OAuth) The ID of the trust authority to use for OAuth authentication
-   * @param {string=} staticToken - Static token that will be used for all authorization in place of normal auth
+   * @param {string=} staticToken - Static token that will be used for all authorization in place of normal auth. Also known as an anonymous token containing the space
    * @param {boolean=} noCache=false - If enabled, blockchain transactions will not be cached
    * @param {boolean=} noAuth=false - If enabled, blockchain authorization will not be performed
    * @param {boolean=} assumeV3=false - If enabled, V3 fabric will be assumed
@@ -577,75 +577,56 @@ class ElvClient {
    * @return {Array<Object>} - A list of nodes in the space matching the parameters
    */
   async SpaceNodes({matchEndpoint, matchNodeId}={}) {
-    let bign = await this.CallContractMethod({
-      contractAddress: this.contentSpaceAddress,
-      methodName: "numActiveNodes",
-    });
-    let n = bign.toNumber();
+    let nodes;
+    this.SetStaticToken();
 
-    return (await Utils.LimitedMap(
-      5,
-      [...new Array(n)],
-      async (_, index) => {
-        let bigi = Ethers.BigNumber.from(index);
-        let addr = await this.CallContractMethod({
-          contractAddress: this.contentSpaceAddress,
-          methodName: "activeNodeAddresses",
-          methodArgs: [bigi],
-          formatArguments: true
-        });
+    if(matchEndpoint) {
+      ({nodes} = await this.utils.ResponseToJson(
+        this.HttpClient.Request({
+          path: UrlJoin("nodes"),
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${this.staticToken}`
+          }
+        })
+      ));
 
-        let nodeId = this.utils.AddressToNodeId(addr);
+      if(!nodes || !Array.isArray(nodes) || nodes.length === 0) {
+        return [];
+      }
 
-        if(matchNodeId && nodeId !== matchNodeId) {
-          return;
-        }
-
-        let locatorsHex = await this.CallContractMethod({
-          contractAddress: this.contentSpaceAddress,
-          methodName: "activeNodeLocators",
-          methodArgs: [bigi]
-        });
-
-        let node = {id: nodeId, endpoints: []};
-
-        // Parse locators CBOR
-        let locators = CBOR.decodeMultiple(
-          Buffer.from(
-            locatorsHex.slice(2, locatorsHex.length),
-            "hex"
-          )
-        );
-
+      return nodes.filter(node => {
         let match = false;
 
-        if(locators.length >= 5) {
-          let fabArray = locators[4].fab;
-          if(fabArray) {
-            for(let i = 0; i < fabArray.length; i ++) {
-              let host = fabArray[i].host;
-
-              if(matchEndpoint && !matchEndpoint.includes(host)) {
-                continue; // Not a match
-              }
-
-              match = true;
-              let endpoint = fabArray[i].scheme + "://" + host;
-
-              if(fabArray[i].port) {
-                endpoint = endpoint + ":" + fabArray[i].port;
-              }
-
-              endpoint = endpoint + "/" + fabArray[i].path;
-              node.endpoints.push(endpoint);
-            }
-          }
+        if(
+          node.services &&
+          node.services.fabric_api &&
+          node.services.fabric_api.urls &&
+          (node.services.fabric_api.urls || []).includes(matchEndpoint)
+        ) {
+          match = true;
         }
 
-        return match ? node : undefined;
-      }
-    ))
-      .filter(n => n);
+        if(matchNodeId && node.id === matchNodeId) {
+          match = true;
+        }
+
+        return match;
+      });
+    } else if(matchNodeId) {
+      this.SetStaticToken();
+      let node = await this.utils.ResponseToJson(
+        this.HttpClient.Request({
+          path: UrlJoin("nodes", matchNodeId),
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${this.staticToken}`
+          }
+        })
+      );
+
+      return [node];
+    }
   }
 
   /**

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -1355,7 +1355,10 @@ exports.StreamConfig = async function({name, customSettings={}, probeMetadata}) 
     status.error = "No node matching stream URL " + streamUrl.href;
     return status;
   }
-  const node = nodes[0];
+  const node = {
+    endpoints: nodes[0].services.fabric_api.urls,
+    id: nodes[0].id
+  };
   status.node = node;
   let endpoint = node.endpoints[0];
 

--- a/test/ElvClient.test.js
+++ b/test/ElvClient.test.js
@@ -2672,6 +2672,29 @@ describe("Test ElvClient", () => {
       await client.DeleteAccessGroup({contractAddress: accessGroupAddress});
     });
   });
+
+  describe("Nodes", () => {
+    let matchEndpoint = process.env.NODE_ENDPOINT;
+    let matchNodeId = process.env.NODE_ID;
+
+    test("List Nodes By Endpoint", async () => {
+      const nodes = await client.SpaceNodes({
+        matchEndpoint
+      });
+
+      expect(nodes).toBeDefined();
+      expect(nodes[0]).toBeDefined();
+    });
+
+    test("List Nodes By ID", async () => {
+      const nodes = await client.SpaceNodes({
+        matchNodeId
+      });
+
+      expect(nodes).toBeDefined();
+      expect(nodes[0]).toBeDefined();
+    });
+  });
 });
 
 if(!module.parent) { runTests(); }


### PR DESCRIPTION
Replace SpaceNodes functionality with a call to /nodes for a list of all nodes of the content space and /nodes/:id to retrieve a specific node.

If matchEndpoint is provided, list of nodes will be filtered by that endpoint AND a node id if matchNodeId is also provided.
Otherwise, if matchNodeId is provided, /nodes/:id is called directly and the response is returned as an array.

NOTE: Nothing uses "cbor-web" or "cbor-x" anymore but ContentObjectVerification uses "cbor".