### PR TITLE
Update test to use existing tenant contract id

### DIFF
--- a/SampleTestConfiguration.json
+++ b/SampleTestConfiguration.json
@@ -1,0 +1,6 @@
+{
+  "config-url": "https://demov3.net955210.contentfabric.io/config",
+  "tenant-contract-id": "itenXXX",
+  "eth-url": "",
+  "fabric-url": "",
+}

--- a/test/ElvClient.test.js
+++ b/test/ElvClient.test.js
@@ -13,6 +13,7 @@ const {
 
 const ClientConfiguration = require("../TestConfiguration");
 const configUrl = process.env["CONFIG_URL"] || ClientConfiguration["config-url"];
+let tenantContractId = process.env["TENANT_CONTRACT_ID"] || ClientConfiguration["tenant-contract-id"] || "";
 
 const Fetch = (input, init={}) => {
   if(typeof fetch === "undefined") {
@@ -46,7 +47,7 @@ let client, accessClient;
 let libraryId, objectId, versionHash, typeId, typeName, typeHash, accessGroupAddress;
 let mediaLibraryId, masterId, masterHash, mezzanineId, linkLibraryId, linkObjectId;
 let s3Access;
-let tenantContractId, tenantId, tenantAdminAddress, contentAdminAddress;
+let tenantId, tenantAdminAddress, contentAdminAddress;
 
 let playoutResult;
 
@@ -101,62 +102,77 @@ describe("Test ElvClient", () => {
     });
     client.SetSigner({signer});
 
-    const spaceOwner = await client.authClient.Owner({address: client.contentSpaceAddress});
-    if(client.signer.address.toString().toLowerCase() !== spaceOwner.toString().toLowerCase()){
-      console.log("require space owner to run this test");
-      return;
+    if(tenantContractId !== ""){
+      console.log("RMMM", tenantContractId);
+      let tenantContractAddress = client.utils.HashToAddress(tenantContractId);
+
+      tenantAdminAddress = await client.CallContractMethod({
+        contractAddress: tenantContractAddress,
+        methodName: "groupsMapping",
+        methodArgs: ["tenant_admin", 0],
+        formatArguments: true,
+      });
+      console.log("RMMM", tenantAdminAddress);
+      expect(tenantAdminAddress).toBeDefined();
+      tenantId = `iten${client.utils.AddressToHash(tenantAdminAddress)}`;
+    } else {
+      const spaceOwner = await client.authClient.Owner({address: client.contentSpaceAddress});
+      if(client.signer.address.toString().toLowerCase() !== spaceOwner.toString().toLowerCase()){
+        console.log("require space owner to run this test");
+        return;
+      }
+
+      // create groups
+      tenantAdminAddress = await client.CreateAccessGroup({name: "tenant_admin group"});
+      expect(tenantAdminAddress).toBeDefined();
+      contentAdminAddress = await client.CreateAccessGroup({name: "content_admin group"});
+      expect(contentAdminAddress).toBeDefined();
+
+      // deploy tenant contract
+      const tenantContractInfo = await client.DeployContract({
+        abi: JSON.parse(tenantAbi),
+        bytecode: tenantBytecode.toString("utf8").replace("\n", ""),
+        constructorArgs: [client.contentSpaceAddress,"TestTenant", client.utils.nullAddress]
+      });
+
+      expect(tenantContractInfo.contractAddress).toBeDefined();
+      const tenantAddress=tenantContractInfo.contractAddress;
+      tenantContractId = `iten${client.utils.AddressToHash(tenantAddress)}`;
+
+      await client.CallContractMethodAndWait({
+        contractAddress: tenantAddress,
+        abi: JSON.parse(tenantAbi),
+        methodName: "addGroup",
+        methodArgs: ["tenant_admin", tenantAdminAddress],
+        formatArguments: true,
+      });
+
+
+      await client.CallContractMethodAndWait({
+        contractAddress: tenantAddress,
+        abi: JSON.parse(tenantAbi),
+        methodName: "addGroup",
+        methodArgs: ["content_admin", contentAdminAddress],
+        formatArguments: true,
+      });
+
+      // set tenant contract in tenant and content admins
+      await client.SetTenantContractId({
+        contractAddress: tenantAdminAddress,
+        tenantContractId
+      });
+      await client.SetTenantContractId({
+        contractAddress: contentAdminAddress,
+        tenantContractId
+      });
     }
 
-    // create groups
-    tenantAdminAddress = await client.CreateAccessGroup({name: "tenant_admin group"});
-    expect(tenantAdminAddress).toBeDefined();
-    contentAdminAddress = await client.CreateAccessGroup({name: "content_admin group"});
-    expect(contentAdminAddress).toBeDefined();
-
-    // deploy tenant contract
-    const tenantContractInfo = await client.DeployContract({
-      abi: JSON.parse(tenantAbi),
-      bytecode: tenantBytecode.toString("utf8").replace("\n", ""),
-      constructorArgs: [client.contentSpaceAddress,"TestTenant", client.utils.nullAddress]
-    });
-
-    expect(tenantContractInfo.contractAddress).toBeDefined();
-    const tenantAddress=tenantContractInfo.contractAddress;
-    tenantContractId = `iten${client.utils.AddressToHash(tenantAddress)}`;
-
-    await client.CallContractMethodAndWait({
-      contractAddress: tenantAddress,
-      abi: JSON.parse(tenantAbi),
-      methodName: "addGroup",
-      methodArgs: ["tenant_admin", tenantAdminAddress],
-      formatArguments: true,
-    });
-
-
-    await client.CallContractMethodAndWait({
-      contractAddress: tenantAddress,
-      abi: JSON.parse(tenantAbi),
-      methodName: "addGroup",
-      methodArgs: ["content_admin", contentAdminAddress],
-      formatArguments: true,
-    });
-
-    // set tenant contract in tenant and content admins
-    await client.SetTenantContractId({
-      contractAddress: tenantAdminAddress,
-      tenantContractId
-    });
-    await client.SetTenantContractId({
-      contractAddress: contentAdminAddress,
-      tenantContractId
-    });
 
     tenantId = `iten${client.utils.AddressToHash(tenantAdminAddress)}`;
     console.log(`\n\nTenant contract deployed:\nTenantContractId:${tenantContractId}\nTenantId:${tenantId}\n\n`);
 
     await client.userProfileClient.SetTenantContractId({tenantContractId});
     expect(client.userProfileClient.tenantContractId).toEqual(tenantContractId);
-
   });
 
   afterAll(async () => {

--- a/test/ElvClient.test.js
+++ b/test/ElvClient.test.js
@@ -59,7 +59,7 @@ let partInfo = {};
 // Describe blocks and  tests within them are run in order
 describe("Test ElvClient", () => {
   beforeAll(async () => {
-    client = OutputLogger(ElvClient, await CreateClient("ElvClient","0.3"));
+    client = OutputLogger(ElvClient, await CreateClient("ElvClient"));
     accessClient = OutputLogger(ElvClient, await CreateClient("ElvClient Access"));
 
     testFile1 = RandomBytes(testFileSize);

--- a/test/PermissionsClient.test.js
+++ b/test/PermissionsClient.test.js
@@ -23,7 +23,7 @@ const later = Date.now() + 365 * 24 * 60 * 60 * 1000;
 describe("Test Permissions Client", () => {
   beforeAll(async () => {
     try {
-      client = await CreateClient("ElvClient", "1");
+      client = await CreateClient("ElvClient");
 
       permissionsClient = OutputLogger(PermissionsClient, new PermissionsClient(client));
 

--- a/test/utils/Utils.js
+++ b/test/utils/Utils.js
@@ -56,8 +56,6 @@ const SetNodes = (client) => {
       throw Error("eth_url is not being set to the provided values");
     }
   }
-
-  console.log("client nodes:", client.Nodes());
 };
 
 const CreateClient = async (name, bux="2") => {

--- a/test/utils/Utils.js
+++ b/test/utils/Utils.js
@@ -58,7 +58,7 @@ const SetNodes = (client) => {
   }
 };
 
-const CreateClient = async (name, bux="2") => {
+const CreateClient = async (name, bux="0.2") => {
   try {
     // Un-initialize global.window so that elv-crypto knows it's running in node
     const w = globalThis.window;


### PR DESCRIPTION
https://github.com/eluv-io/elv-client-js/issues/276

* uses `tenant-contract-id` provided as enviroment variable or in config file (added sample config).
```
let tenantContractId = process.env["TENANT_CONTRACT_ID"] || ClientConfiguration["tenant-contract-id"] || "";
```
* checks if the private_key provided is tenant root key.
* checks if the tenant admin group is set for tenant contract id provided.
* reduced the funds to 0.2elv for all tests. 
* Tested in local dev setup.