### PR TITLE
Update ListFiles() to support write token, path, Files API v2. Protect against pollution of Networks()

### DIFF
--- a/src/ElvClient.js
+++ b/src/ElvClient.js
@@ -283,7 +283,7 @@ class ElvClient {
    * @return {Object} - An object using network names as keys and configuration URLs as values.
    */
   static Networks() {
-    return networks;
+    return Object.assign({}, networks);
   }
 
   /**

--- a/src/Validation.js
+++ b/src/Validation.js
@@ -52,8 +52,11 @@ exports.ValidatePartHash = (partHash) => {
   }
 };
 
-exports.ValidateParameters = ({libraryId, objectId, versionHash}) => {
-  if(versionHash) {
+exports.ValidateParameters = ({libraryId, objectId, versionHash, writeToken}) => {
+  if(writeToken) {
+    if(versionHash)  throw Error(`Cannot specify writeToken and versionHash at same time (token:${writeToken}, hash:${versionHash})`);
+    exports.ValidateWriteToken(writeToken);
+  } else if(versionHash) {
     exports.ValidateVersion(versionHash);
   } else {
     exports.ValidateLibrary(libraryId);

--- a/src/client/Files.js
+++ b/src/client/Files.js
@@ -34,20 +34,22 @@ const {
  * @namedParams
  * @param {string=} libraryId - ID of the library
  * @param {string=} objectId - ID of the object
+ * @param {string=} path - ID of the object
  * @param {string=} versionHash - Hash of the object version - if not specified, most recent version will be used
+ * @param {string=} writeToken - Write token of a draft (incompatible with versionHash)
  */
-exports.ListFiles = async function({libraryId, objectId, versionHash}) {
-  ValidateParameters({libraryId, objectId, versionHash});
+exports.ListFiles = async function({libraryId, objectId, path = "", versionHash, writeToken}) {
+  ValidateParameters({libraryId, objectId, versionHash, writeToken});
 
   if(versionHash) { objectId = this.utils.DecodeVersionHash(versionHash).objectId; }
 
-  let path = UrlJoin("q", versionHash || objectId, "meta", "files");
+  let urlPath = UrlJoin("q", writeToken || versionHash || objectId, "files_list", path);
 
   return this.utils.ResponseToJson(
     this.HttpClient.Request({
       headers: await this.authClient.AuthorizationHeader({libraryId, objectId, versionHash}),
       method: "GET",
-      path: path,
+      path: urlPath,
     })
   );
 };
@@ -554,7 +556,7 @@ exports.UploadFileData = async function({libraryId, objectId, writeToken, encryp
   const jobStatus = await this.UploadJobStatus({libraryId, objectId, writeToken, uploadId, jobId});
 
   // Find the status of this file
-  let fileStatus = jobStatus.files.find(item => item.path == filePath);
+  let fileStatus = jobStatus.files.find(item => item.path === filePath);
   if(encryption && encryption !== "none") {
     fileStatus = fileStatus.encrypted;
   }


### PR DESCRIPTION
 * `ListFiles()` changes:
   * Add support for getting info from a draft using a `writeToken`
   * Add support for requesting a list from a subdirectory using `path` (return value will be recursive list)
   * Change URL to Files API version2 
 * Protect against tampering of `networks` var by having `Networks()` return a copy of the object rather than original
 * Fix  'type coercion' warning  (`==` vs `===`) in `UploadFileData()`