### PR TITLE
Add objects basic operations script and update publishContentVersion method

### DIFF
--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -1006,7 +1006,7 @@ exports.PublishContentVersion = async function({objectId, versionHash, awaitComm
   });
 
   const abi = await this.ContractAbi({id: objectId});
-  const fromBlock = commit.blockNumber - 10; // due to block re-org
+  const fromBlock = commit.blockNumber - 30; // due to block re-org
 
   const objectHash = await this.ExtractValueFromEvent({
     abi,
@@ -1051,7 +1051,6 @@ exports.PublishContentVersion = async function({objectId, versionHash, awaitComm
       }
     }
   }
-
 
   // APIv2 ensure the fabric API returns the correct hash
   if(awaitCommitConfirmation) {

--- a/testScripts/BasicObjectOperations.js
+++ b/testScripts/BasicObjectOperations.js
@@ -1,0 +1,93 @@
+/* eslint-disable no-console */
+
+const { ElvClient } = require("../src/ElvClient");
+
+const configUrl = "https://test.net955205.contentfabric.io/config";
+const libraryId = "ilibE6vhm2YCR6vZCtW9mope6Dbo2Tn"; // to create and edit content
+
+const Tool = async () => {
+
+  const client = await ElvClient.FromConfigurationUrl({configUrl});
+
+  let wallet = client.GenerateWallet();
+  let signer = wallet.AddAccount({
+    privateKey: process.env.PRIVATE_KEY
+  });
+
+  client.SetSigner({signer});
+  client.ToggleLogging(true);
+
+
+  try {
+    let start = new Date().getTime();
+    const {objectId, writeToken} = await client.CreateContentObject({
+      libraryId: libraryId,
+      options: {
+        meta: {commit: "Create Content-" + start.toString()}
+      }
+    });
+    let end = new Date().getTime();
+    let timeDifference = end - start;
+    console.log("content object completed after: ", timeDifference, "ms");
+
+    start = new Date().getTime();
+    const {hash} = await client.FinalizeContentObject({
+      libraryId,
+      objectId,
+      writeToken
+    });
+    end = new Date();
+    timeDifference = end - start;
+    console.log("finalize object completed after: ", timeDifference, "ms");
+
+    start = new Date().getTime();
+    const editResponse = await client.EditContentObject({
+      libraryId,
+      objectId,
+    });
+    end = new Date().getTime();
+    timeDifference = end - start;
+    console.log("edit object completed after: ", timeDifference, "ms");
+
+    const metadata = {
+      description: "edit content",
+    };
+
+    start = new Date().getTime();
+    await client.ReplaceMetadata({
+      libraryId,
+      objectId,
+      writeToken: editResponse.write_token,
+      metadata
+    });
+    end = new Date().getTime();
+    timeDifference = end - start;
+    console.log("replace metadata completed after: ", timeDifference, "ms");
+
+
+    start = new Date().getTime();
+    await client.FinalizeContentObject({
+      libraryId,
+      objectId,
+      writeToken: editResponse.write_token,
+    });
+    end = new Date().getTime();
+    timeDifference = end - start;
+    console.log("finalize object completed after: ", timeDifference, "ms");
+
+    console.log(`\nSuccessfully created new content version: ${hash}`);
+  } catch(error) {
+    console.error("Error creating content object:");
+    console.error(error);
+  }
+};
+
+const privateKey = process.env.PRIVATE_KEY;
+if(!privateKey) {
+  console.error("PRIVATE_KEY environment variable must be specified");
+  return;
+}
+
+Tool();
+
+


### PR DESCRIPTION
1. **testScripts/BasicObjectOperations.js**: To track the time taken by create, finalize and edit content methods in tv4 or dv3.
2. **Update `PublishContentVersion` to:**
* manage block re-org by filtering `VersionConfirm` events and the `object hash` starting from last 10 blocks.
* introduced a 2-minute timeout for the loop to prevent continuous retries in case events are not found.

