### PR TITLE
Allow debug logging of fetch params and (some) JSON and text response bodies

### DIFF
--- a/src/EthClient.js
+++ b/src/EthClient.js
@@ -279,6 +279,7 @@ class EthClient {
       while(!success) {
         try {
           result = await contract[methodName](...methodArgs, overrides);
+          if(this.debug) this.Log(`result: ${result}`);
           success = true;
         } catch(error) {
           if(error.code === -32000 || error.code === "REPLACEMENT_UNDERPRICED") {

--- a/src/EthClient.js
+++ b/src/EthClient.js
@@ -279,7 +279,6 @@ class EthClient {
       while(!success) {
         try {
           result = await contract[methodName](...methodArgs, overrides);
-          if(this.debug) this.Log(`result: ${result}`);
           success = true;
         } catch(error) {
           if(error.code === -32000 || error.code === "REPLACEMENT_UNDERPRICED") {

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -1,6 +1,7 @@
 const URI = require("urijs");
 const Fetch = typeof fetch !== "undefined" ? fetch : require("node-fetch").default;
 const {LogMessage} = require("./LogMessage");
+const Utils = require("./Utils");
 
 class HttpClient {
   Log(message, error=false) {
@@ -100,7 +101,10 @@ class HttpClient {
     }
 
     let response;
-    this.Log(`${method} - ${uri.toString()}`);
+    if(this.debug) {
+      this.Log(`${method} - ${uri.toString()}`);
+      this.Log(`fetchParameters: ${JSON.stringify(fetchParameters, null, 2)}`);
+    }
     try {
       response =
         await HttpClient.Fetch(
@@ -166,7 +170,7 @@ class HttpClient {
         requestParams: fetchParameters
       };
 
-      this.Log(
+      if(this.debug) this.Log(
         JSON.stringify(error, null, 2),
         true
       );
@@ -205,6 +209,16 @@ class HttpClient {
             return error;
           }
         })
+    );
+  }
+
+  // Perform http request and then return response body parsed as JSON
+  // ResponseToJson() will log response if this.debug === true
+  async RequestJsonBody(params) {
+    return Utils.ResponseToJson(
+      this.Request(params),
+      this.debug,
+      this.Log.bind(this)
     );
   }
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -545,18 +545,40 @@ const Utils = {
     });
   },
 
-  ResponseToJson: async (response) => {
-    return Utils.ResponseToFormat("json", response);
+  /**
+   * Interprets an http response body obtained from an http call as JSON and returns result of parsing it.
+   *
+   * @param {Promise} response - An http response from node-fetch
+   * @param {boolean=} debug - Whether or not to log the body
+   * @param {Function} logFn - Log function to use if debug === true
+   * @return {*} - Result of parsing response body as JSON
+   */
+  ResponseToJson: async (response, debug = false, logFn) => {
+    return await Utils.ResponseToFormat("json", response, debug, logFn);
   },
 
-  ResponseToFormat: async (format, response) => {
+  /**
+   * Interprets an http response body obtained from an http call as a requested format and returns result of converting/formatting.
+   *
+   * @param {string} format - The format to use when interpreting response body (e.g. "json", "text" et. al.)
+   * @param {Promise} response - An http response from node-fetch
+   * @param {boolean=} debug - Whether or not to log a debug statement containing the body (ignored for formats other than "json" and "text")
+   * @param {Function} logFn - Log function to use if debug === true
+   * @return {*} - Result of converting response body into the requested format
+   */
+  ResponseToFormat: async (format, response, debug = false, logFn) => {
     response = await response;
+    let formattedBody;
 
     switch(format.toLowerCase()) {
       case "json":
-        return await response.json();
+        formattedBody = await response.json();
+        if(debug) logFn(`response body: ${JSON.stringify(formattedBody, null, 2)}`);
+        return formattedBody;
       case "text":
-        return await response.text();
+        formattedBody = await response.text();
+        if(debug) logFn(`response body: ${formattedBody}`);
+        return formattedBody;
       case "blob":
         return await response.blob();
       case "arraybuffer":

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -550,7 +550,7 @@ const Utils = {
    *
    * @param {Promise} response - An http response from node-fetch
    * @param {boolean=} debug - Whether or not to log the body
-   * @param {Function} logFn - Log function to use if debug === true
+   * @param {Function} logFn - Log function to use if debug is truthy
    * @return {*} - Result of parsing response body as JSON
    */
   ResponseToJson: async (response, debug = false, logFn) => {
@@ -563,7 +563,7 @@ const Utils = {
    * @param {string} format - The format to use when interpreting response body (e.g. "json", "text" et. al.)
    * @param {Promise} response - An http response from node-fetch
    * @param {boolean=} debug - Whether or not to log a debug statement containing the body (ignored for formats other than "json" and "text")
-   * @param {Function} logFn - Log function to use if debug === true
+   * @param {Function} logFn - Log function to use if debug is truthy
    * @return {*} - Result of converting response body into the requested format
    */
   ResponseToFormat: async (format, response, debug = false, logFn) => {

--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -390,7 +390,7 @@ exports.ContentLibrary = async function({libraryId}) {
 
   const path = UrlJoin("qlibs", libraryId);
 
-  const library = await this.HttpClient.RequestJSON({
+  const library = await this.HttpClient.RequestJsonBody({
     headers: await this.authClient.AuthorizationHeader({libraryId}),
     method: "GET",
     path: path

--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -2374,15 +2374,17 @@ exports.ContentObjectGraph = async function({libraryId, objectId, versionHash, a
   let path = UrlJoin("q", versionHash || objectId, "links");
 
   try {
-    return await this.HttpClient.RequestJsonBody({
-      headers: await this.authClient.AuthorizationHeader({libraryId, objectId, versionHash}),
-      queryParams: {
-        auto_update: autoUpdate,
-        select
-      },
-      method: "GET",
-      path: path,
-    });
+    return await this.utils.ResponseToJson(
+      this.HttpClient.Request({
+        headers: await this.authClient.AuthorizationHeader({libraryId, objectId, versionHash}),
+        queryParams: {
+          auto_update: autoUpdate,
+          select
+        },
+        method: "GET",
+        path: path,
+      })
+    );
   } catch(error) {
     // If a cycle is present, do some work to present useful information about it
     let errorInfo;
@@ -3088,11 +3090,13 @@ exports.Proofs = async function({libraryId, objectId, versionHash, partHash}) {
 
   let path = UrlJoin("q", versionHash || objectId, "data", partHash, "proofs");
 
-  return this.HttpClient.RequestJsonBody({
-    headers: await this.authClient.AuthorizationHeader({libraryId, objectId, versionHash}),
-    method: "GET",
-    path: path
-  });
+  return this.utils.ResponseToJson(
+    this.HttpClient.Request({
+      headers: await this.authClient.AuthorizationHeader({libraryId, objectId, versionHash}),
+      method: "GET",
+      path: path
+    })
+  );
 };
 
 /**

--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -390,13 +390,11 @@ exports.ContentLibrary = async function({libraryId}) {
 
   const path = UrlJoin("qlibs", libraryId);
 
-  const library = await this.utils.ResponseToJson(
-    this.HttpClient.Request({
-      headers: await this.authClient.AuthorizationHeader({libraryId}),
-      method: "GET",
-      path: path
-    })
-  );
+  const library = await this.HttpClient.RequestJSON({
+    headers: await this.authClient.AuthorizationHeader({libraryId}),
+    method: "GET",
+    path: path
+  });
 
   return {
     ...library,
@@ -566,14 +564,12 @@ exports.ContentObjects = async function({libraryId, filterOptions={}}) {
   this.Log("Filter options:");
   this.Log(filterOptions);
 
-  return await this.utils.ResponseToJson(
-    this.HttpClient.Request({
-      headers: await this.authClient.AuthorizationHeader({libraryId}),
-      method: "GET",
-      path: path,
-      queryParams
-    })
-  );
+  return await this.HttpClient.RequestJsonBody({
+    headers: await this.authClient.AuthorizationHeader({libraryId}),
+    method: "GET",
+    path: path,
+    queryParams
+  });
 };
 
 /**
@@ -597,13 +593,11 @@ exports.ContentObject = async function({libraryId, objectId, versionHash, writeT
 
   let path = UrlJoin("q", writeToken || versionHash || objectId);
 
-  return await this.utils.ResponseToJson(
-    this.HttpClient.Request({
-      headers: await this.authClient.AuthorizationHeader({libraryId, objectId, versionHash}),
-      method: "GET",
-      path: path
-    })
-  );
+  return await this.HttpClient.RequestJsonBody({
+    headers: await this.authClient.AuthorizationHeader({libraryId, objectId, versionHash}),
+    method: "GET",
+    path: path
+  });
 };
 
 /**
@@ -919,22 +913,20 @@ exports.ContentObjectMetadata = async function({
 
   let metadata;
   try {
-    metadata = await this.utils.ResponseToJson(
-      this.HttpClient.Request({
-        headers: { "Authorization": authTokens.map(token => `Bearer ${token}`) },
-        queryParams: {
-          ...queryParams,
-          select,
-          remove,
-          link_depth: linkDepthLimit,
-          resolve: resolveLinks,
-          resolve_include_source: resolveIncludeSource,
-          resolve_ignore_errors: resolveIgnoreErrors,
-        },
-        method: "GET",
-        path: path
-      })
-    );
+    metadata = await this.HttpClient.RequestJsonBody({
+      headers: { "Authorization": authTokens.map(token => `Bearer ${token}`) },
+      queryParams: {
+        ...queryParams,
+        select,
+        remove,
+        link_depth: linkDepthLimit,
+        resolve: resolveLinks,
+        resolve_include_source: resolveIncludeSource,
+        resolve_ignore_errors: resolveIgnoreErrors,
+      },
+      method: "GET",
+      path: path
+    });
   } catch(error) {
     if(error.status !== 404) {
       throw error;
@@ -1066,13 +1058,11 @@ exports.ContentObjectVersions = async function({libraryId, objectId}) {
 
   let path = UrlJoin("qid", objectId);
 
-  return this.utils.ResponseToJson(
-    this.HttpClient.Request({
-      headers: await this.authClient.AuthorizationHeader({libraryId, objectId}),
-      method: "GET",
-      path: path
-    })
-  );
+  return this.HttpClient.RequestJsonBody({
+    headers: await this.authClient.AuthorizationHeader({libraryId, objectId}),
+    method: "GET",
+    path: path
+  });
 };
 
 /**
@@ -1143,13 +1133,11 @@ exports.LatestVersionHashV2 = async function({objectId, versionHash}) {
   try {
     let path = UrlJoin("q", objectId);
 
-    let q = await this.utils.ResponseToJson(
-      this.HttpClient.Request({
-        headers: await this.authClient.AuthorizationHeader({objectId}),
-        method: "GET",
-        path: path
-      })
-    );
+    let q = await this.HttpClient.RequestJsonBody({
+      headers: await this.authClient.AuthorizationHeader({objectId}),
+      method: "GET",
+      path: path
+    });
     latestHash = q.hash;
 
   } catch(error) {
@@ -1379,15 +1367,13 @@ exports.AvailableOfferings = async function({
       .flat()
       .filter(token => token);
 
-    return await this.utils.ResponseToJson(
-      this.HttpClient.Request({
-        path: path,
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${authorization.join(",")}`
-        }
-      })
-    );
+    return await this.HttpClient.RequestJsonBody({
+      path: path,
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${authorization.join(",")}`
+      }
+    });
   } catch(error) {
     if(error.status && parseInt(error.status) === 500) {
       return {};
@@ -1526,13 +1512,11 @@ exports.PlayoutOptions = async function({
   };
 
   const playoutOptions = Object.values(
-    await this.utils.ResponseToJson(
-      this.HttpClient.Request({
-        path,
-        method: "GET",
-        queryParams
-      })
-    )
+    await this.HttpClient.RequestJsonBody({
+      path,
+      method: "GET",
+      queryParams
+    })
   );
 
   if(!signedLink && linkTarget.versionHash) {
@@ -1638,17 +1622,14 @@ exports.PlayoutOptions = async function({
     playoutMap.multiview = true;
 
     playoutMap.AvailableViews = async () => {
-      return await this.utils.ResponseToFormat(
-        "json",
-        await this.HttpClient.Request({
-          path: UrlJoin("q", linkTarget.versionHash || versionHash, "rep", handler, offering, "views.json"),
-          method: "GET",
-          queryParams: {
-            sid: sessionId,
-            authorization
-          }
-        })
-      );
+      return await this.HttpClient.RequestJsonBody({
+        path: UrlJoin("q", linkTarget.versionHash || versionHash, "rep", handler, offering, "views.json"),
+        method: "GET",
+        queryParams: {
+          sid: sessionId,
+          authorization
+        }
+      });
     };
 
     playoutMap.SwitchView = async (view) => {
@@ -1882,7 +1863,9 @@ exports.CallBitcodeMethod = async function({
       path,
       queryParams,
       allowFailover: false
-    })
+    }),
+    this.HttpClient.debug,
+    this.HttpClient.Log.bind(this.HttpClient)
   );
 };
 
@@ -2391,17 +2374,15 @@ exports.ContentObjectGraph = async function({libraryId, objectId, versionHash, a
   let path = UrlJoin("q", versionHash || objectId, "links");
 
   try {
-    return await this.utils.ResponseToJson(
-      this.HttpClient.Request({
-        headers: await this.authClient.AuthorizationHeader({libraryId, objectId, versionHash}),
-        queryParams: {
-          auto_update: autoUpdate,
-          select
-        },
-        method: "GET",
-        path: path,
-      })
-    );
+    return await this.HttpClient.RequestJsonBody({
+      headers: await this.authClient.AuthorizationHeader({libraryId, objectId, versionHash}),
+      queryParams: {
+        auto_update: autoUpdate,
+        select
+      },
+      method: "GET",
+      path: path,
+    });
   } catch(error) {
     // If a cycle is present, do some work to present useful information about it
     let errorInfo;
@@ -3107,13 +3088,11 @@ exports.Proofs = async function({libraryId, objectId, versionHash, partHash}) {
 
   let path = UrlJoin("q", versionHash || objectId, "data", partHash, "proofs");
 
-  return this.utils.ResponseToJson(
-    this.HttpClient.Request({
-      headers: await this.authClient.AuthorizationHeader({libraryId, objectId, versionHash}),
-      method: "GET",
-      path: path
-    })
-  );
+  return this.HttpClient.RequestJsonBody({
+    headers: await this.authClient.AuthorizationHeader({libraryId, objectId, versionHash}),
+    method: "GET",
+    path: path
+  });
 };
 
 /**

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -183,8 +183,13 @@ exports.CreateContentType = async function({name, metadata={}, bitcode}) {
     path: path
   });
   // extract the url for the node that handled the request
+  // TODO: remove/simplify after we start using /nodes API call to get node URLs for write tokens
   const nodeUrl = (new URL(rawCreateResponse.url)).origin;
-  const createResponse = await this.utils.ResponseToJson(rawCreateResponse);
+  const createResponse = await this.utils.ResponseToJson(
+    rawCreateResponse,
+    this.HttpClient.debug,
+    this.HttpClient.Log.bind(this.HttpClient)
+  );
 
   // Record the node used in creating this write token
   this.RecordWriteToken({writeToken: createResponse.write_token, fabricNodeUrl: nodeUrl});
@@ -602,8 +607,14 @@ exports.CreateContentObject = async function({libraryId, objectId, options={}}) 
     path: path,
     body: options
   });
+  // extract the url for the node that handled the request
+  // TODO: remove/simplify after we start using /nodes API call to get node URLs for write tokens
   const nodeUrl = (new URL(rawCreateResponse.url)).origin;
-  const createResponse = await this.utils.ResponseToJson(rawCreateResponse);
+  const createResponse = await this.utils.ResponseToJson(
+    rawCreateResponse,
+    this.HttpClient.debug,
+    this.HttpClient.Log.bind(this.HttpClient)
+  );
 
   // Record the node used in creating this write token
   this.RecordWriteToken({writeToken: createResponse.write_token, fabricNodeUrl: nodeUrl});
@@ -773,8 +784,13 @@ exports.EditContentObject = async function({libraryId, objectId, options={}}) {
     body: options
   });
   // extract the url for the node that handled the request
+  // TODO: remove/simplify after we start using /nodes API call to get node URLs for write tokens
   const nodeUrl = (new URL(rawEditResponse.url)).origin;
-  const editResponse = await this.utils.ResponseToJson(rawEditResponse);
+  const editResponse = await this.utils.ResponseToJson(
+    rawEditResponse,
+    this.HttpClient.debug,
+    this.HttpClient.Log.bind(this.HttpClient)
+  );
 
   // Record the node used in creating this write token
   this.RecordWriteToken({writeToken: editResponse.write_token, fabricNodeUrl: nodeUrl});
@@ -957,14 +973,12 @@ exports.FinalizeContentObject = async function({
 
   let path = UrlJoin("q", writeToken);
 
-  const finalizeResponse = await this.utils.ResponseToJson(
-    this.HttpClient.Request({
-      headers: await this.authClient.AuthorizationHeader({libraryId, objectId, update: true}),
-      method: "POST",
-      path: path,
-      allowFailover: false
-    })
-  );
+  const finalizeResponse = await this.HttpClient.RequestJsonBody({
+    headers: await this.authClient.AuthorizationHeader({libraryId, objectId, update: true}),
+    method: "POST",
+    path: path,
+    allowFailover: false
+  });
 
   this.Log(`Finalized: ${finalizeResponse.hash}`);
 

--- a/src/client/Files.js
+++ b/src/client/Files.js
@@ -502,12 +502,14 @@ exports.UploadStatus = async function({libraryId, objectId, writeToken, uploadId
 
   const path = UrlJoin("q", writeToken, "file_jobs", uploadId);
 
-  return this.HttpClient.RequestJsonBody({
-    headers: await this.authClient.AuthorizationHeader({libraryId, objectId, update: true}),
-    method: "GET",
-    path: path,
-    allowFailover: false
-  });
+  return this.utils.ResponseToJson(
+    this.HttpClient.Request({
+      headers: await this.authClient.AuthorizationHeader({libraryId, objectId, update: true}),
+      method: "GET",
+      path: path,
+      allowFailover: false
+    })
+  );
 };
 
 exports.UploadJobStatus = async function({libraryId, objectId, writeToken, uploadId, jobId}) {
@@ -516,22 +518,26 @@ exports.UploadJobStatus = async function({libraryId, objectId, writeToken, uploa
 
   const path = UrlJoin("q", writeToken, "file_jobs", uploadId, "uploads", jobId);
 
-  let response = await this.HttpClient.RequestJsonBody({
-    headers: await this.authClient.AuthorizationHeader({libraryId, objectId, update: true}),
-    method: "GET",
-    path: path,
-    allowFailover: false,
-    queryParams: { start: 0, limit: 10000 }
-  });
-
-  while(response.next !== response.total && response.next >= 0) {
-    const newResponse = await this.HttpClient.RequestJsonBody({
+  let response = await this.utils.ResponseToJson(
+    this.HttpClient.Request({
       headers: await this.authClient.AuthorizationHeader({libraryId, objectId, update: true}),
       method: "GET",
       path: path,
       allowFailover: false,
-      queryParams: { start: response.next }
-    });
+      queryParams: { start: 0, limit: 10000 }
+    })
+  );
+
+  while(response.next !== response.total && response.next >= 0) {
+    const newResponse = await this.utils.ResponseToJson(
+      this.HttpClient.Request({
+        headers: await this.authClient.AuthorizationHeader({libraryId, objectId, update: true}),
+        method: "GET",
+        path: path,
+        allowFailover: false,
+        queryParams: { start: response.next }
+      })
+    );
 
     response.files = [
       ...response.files,
@@ -564,18 +570,20 @@ exports.UploadFileData = async function({libraryId, objectId, writeToken, encryp
 
   let path = UrlJoin("q", writeToken, "file_jobs", uploadId, jobId);
 
-  return await this.HttpClient.RequestJsonBody({
-    method: "POST",
-    path: path,
-    body: fileData,
-    bodyType: "BINARY",
-    headers: {
-      "Content-type": "application/octet-stream",
-      ...(await this.authClient.AuthorizationHeader({libraryId, objectId, update: true}))
-    },
-    allowFailover: false,
-    allowRetry: false
-  });
+  return await this.utils.ResponseToJson(
+    this.HttpClient.Request({
+      method: "POST",
+      path: path,
+      body: fileData,
+      bodyType: "BINARY",
+      headers: {
+        "Content-type": "application/octet-stream",
+        ...(await this.authClient.AuthorizationHeader({libraryId, objectId, update: true}))
+      },
+      allowFailover: false,
+      allowRetry: false
+    })
+  );
 };
 
 exports.FinalizeUploadJob = async function({libraryId, objectId, writeToken}) {
@@ -1104,14 +1112,16 @@ exports.UploadPartChunk = async function({libraryId, objectId, writeToken, partW
   }
 
   const path = UrlJoin("q", writeToken, "parts");
-  await this.HttpClient.RequestJsonBody({
-    headers: await this.authClient.AuthorizationHeader({libraryId, objectId, update: true, encryption}),
-    method: "POST",
-    path: UrlJoin(path, partWriteToken),
-    body: chunk,
-    bodyType: "BINARY",
-    allowFailover: false
-  });
+  await this.utils.ResponseToJson(
+    this.HttpClient.Request({
+      headers: await this.authClient.AuthorizationHeader({libraryId, objectId, update: true, encryption}),
+      method: "POST",
+      path: UrlJoin(path, partWriteToken),
+      body: chunk,
+      bodyType: "BINARY",
+      allowFailover: false
+    })
+  );
 };
 
 /**


### PR DESCRIPTION
Changes to provide additional info in debug log output:

- HttpClient
	- Add logging of fetch parameters by `HttpClient.Request()`
	- Allow selected functions to log JSON response body obtained from `HttpClient.Request()` *(requires modification of calling function)*
		- Implemented via new function `HttpClient.RequestJsonBody()` that can substitute for `Utils.ResponseToJson(HttpClient.Request(...))` _(couldn't just put the log statement directly inside `HttpClient.Request()` because response body cannot be consumed twice)_
		- To have a function support logging response body, modify to use `RequestJsonBody(...)` instead of `ResponseToJson(Request(...))`

- ElvClient
	- Modified the following functions to use `HttpClient.RequestJsonBody()` instead of `Utils.ResponseToJson(HttpClient.Request(...))`:
		- ContentAccess
			- `AvailableOfferings()`
			- `CallBitcodeMethod()`
			- `ContentLibrary()`
			- `ContentObject()`
			- `ContentObjectMetadata()`
			- `ContentObjects()`
			- `ContentObjectVersions()`
			- `LatestVersionHashV2()`
			- `PlayoutOptions()`
		- ContentManagement
			- `CreateContentObject()`
			- `CreateContentType()`
			- `EditContentObject()`
			- `FinalizeContentObject()`
		- Files
			- `ContentPart()`
			- `ContentParts()`
			- `CreateFileUploadJob()`
			- `CreatePart()`
			- `FinalizePart()`
			- `ListFiles()`

- Utils
	- Added optional debug response body logging to `Utils.ResponseToJson()` and `Utils.ResponseToFormat()`. 
	- Caller can supply 2 additional args (debug flag and logging function) and response body will be logged (when `debug` is truthy and requested format is JSON or text ). 
	- `HttpClient.RequestJsonBody()` automatically passes in `HttpClient.debug` and `HttpClient.Log`  to `Utils.ResponseToJson()`, so functions that have been modified to use `HttpClient.RequestJsonBody()` will include response bodies in debug log
	- Added JSDoc comments to `Utils.ResponseToJson()` and `Utils.ResponseToFormat()`

- Misc
	- Prevent some `Log` calls when debug is not enabled (to avoid unnecessary `JSON.stringify()` calls)
	- Modify log message for `UploadFilesFromS3()` depending on whether files are being copied or linked.