### PR TITLE
Parse hostname from live stream url to match node

### DIFF
--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -1350,7 +1350,11 @@ exports.StreamConfig = async function({name, customSettings={}, probeMetadata}) 
   status.user_config = userConfig;
 
   // Get node URI from user config
-  const hostName = userConfig.url.replace("udp://", "").replace("rtmp://", "").replace("srt://", "").split(":")[0];
+  const parsedName = userConfig.url
+    .replace("udp://", "https://")
+    .replace("rtmp://", "https://")
+    .replace("srt://", "https://");
+  const hostName = new URL(parsedName).hostname;
   const streamUrl = new URL(userConfig.url);
 
   console.log("Retrieving nodes - matching", hostName);


### PR DESCRIPTION
Use URL constructor to parse live stream URL hostname in order to match the node returned by SpaceNodes.
Cases tested:
- "rtmp://host-76-74-28-234.contentfabric.io/rtmp/6Sada7R4"
- "rtmp://host-76-74-28-234.contentfabric.io:1935/rtmp/6Sada7R4"
- "srt://host-76-74-28-235.contentfabric.io:11001?mode=listener"
- "srt://host-76-74-28-235.contentfabric.io?mode=listener"
- "udp://host-76-74-28-234.contentfabric.io:11041"
- "udp://host-76-74-28-234.contentfabric.io"
