### PR TITLE
Download media object

### DIFF
--- a/testScripts/BasicObjectOperations.js
+++ b/testScripts/BasicObjectOperations.js
@@ -3,7 +3,7 @@
 const { ElvClient } = require("../src/ElvClient");
 
 const configUrl = "https://test.net955205.contentfabric.io/config";
-const libraryId = "iliboE2t6fcJxUKPJ1G9q9hUd3bFBaG"; // to create and edit content
+const libraryId = "ilibE6vhm2YCR6vZCtW9mope6Dbo2Tn"; // to create and edit content
 
 const Tool = async () => {
 

--- a/testScripts/BasicObjectOperations.js
+++ b/testScripts/BasicObjectOperations.js
@@ -3,7 +3,7 @@
 const { ElvClient } = require("../src/ElvClient");
 
 const configUrl = "https://test.net955205.contentfabric.io/config";
-const libraryId = "ilibE6vhm2YCR6vZCtW9mope6Dbo2Tn"; // to create and edit content
+const libraryId = "iliboE2t6fcJxUKPJ1G9q9hUd3bFBaG"; // to create and edit content
 
 const Tool = async () => {
 
@@ -15,7 +15,7 @@ const Tool = async () => {
   });
 
   client.SetSigner({signer});
-  client.ToggleLogging(true);
+  //client.ToggleLogging(true);
 
 
   try {

--- a/testScripts/ObjectDownloadMedia.js
+++ b/testScripts/ObjectDownloadMedia.js
@@ -1,0 +1,115 @@
+/* eslint-disable no-console */
+const ScriptBase = require("./parentClasses/ScriptBase");
+const utils = require("../src/Utils");
+const Fraction = require("fraction.js");
+const {JSONPath} = require("jsonpath-plus");
+
+class ObjectDownloadMedia extends ScriptBase {
+  async body() {
+    const client = await this.client();
+
+    let objectId = this.args.objectId;
+    const versionHash = this.args.objectHash;
+    const offeringType = this.args.offeringType || "default";
+    const startTime = this.args.startTime;
+    const endTime = this.args.endTime;
+
+    if(objectId === undefined){
+      if(versionHash===undefined){
+        throw Error("require object-id or object-hash to be provided");
+      }
+      const res = utils.DecodeVersionHash(versionHash);
+      objectId = res.objectId;
+    }
+
+    const sourcesJsonPath = "offerings." + offeringType + ".media_struct.streams.video.sources[*]";
+    const libraryId = await client.ContentObjectLibraryId({objectId, versionHash});
+    const totalDurationJsonPath = "offerings." + offeringType + ".media_struct.streams.video.duration";
+
+    // get object metadata
+    let metadata = await client.ContentObjectMetadata({
+      libraryId,
+      objectId
+    });
+
+    let sourcesMetadata = JSONPath({
+      json: metadata,
+      path: sourcesJsonPath,
+      wrap: false
+    });
+    if(sourcesMetadata === undefined) {
+      throw new Error("no matching offerings metadata found");
+    }
+
+    let totalDurationMetadata = JSONPath({
+      json: metadata,
+      path: totalDurationJsonPath,
+      wrap: false
+    });
+    if(totalDurationMetadata === undefined) {
+      throw new Error("no matching total duration metadata found");
+    }
+
+    const totalDurationTimeBase = new Fraction(totalDurationMetadata.time_base);
+    const totalDuration = new Fraction(totalDurationMetadata.ts).mul(totalDurationTimeBase);
+    if(startTime < 0 || endTime > totalDuration) {
+      throw new Error(`start or end time provided are not within range: ${totalDuration}s`);
+    }
+
+    const sourcesTimeInfo = sourcesMetadata.map((item) => {
+      // start = item.timeline_start.ts * item.timeline_start.time_base
+      const startTimeBase = new Fraction(item.timeline_start.time_base);
+      const start = new Fraction(item.timeline_start.ts).mul(startTimeBase);
+      // end = item.timeline_start.ts * item.timeline_end.time_base
+      const endTimeBase = new Fraction(item.timeline_end.time_base);
+      const end = new Fraction(item.timeline_end.ts).mul(endTimeBase);
+
+      return {
+        start: start.valueOf(),
+        end: end.valueOf(),
+        source: item.source
+      };
+    });
+
+    let parts = [];
+    sourcesTimeInfo.forEach(item => {
+      if(startTime < item.end && endTime > item.start){
+        parts.push(item.source);
+      }
+    });
+    console.log(parts);
+  }
+
+  header() {
+    return `Downloading parts for objectId ${this.args.objectId} from startTime: ${this.args.startTime}s to endTime: ${this.args.endTime}s`;
+  }
+
+  options() {
+    return super.options()
+      .option("objectId", {
+        alias: "object-id",
+        describe: "Object ID (should start with 'iq__')",
+        type: "string"
+      })
+      .option("objectHash", {
+        alias: "object-hash",
+        describe: "Object Hash (should start with 'hq__')",
+        type: "string"
+      })
+      .option("offeringType", {
+        describe: "offerings type (default: 'default')",
+        type: "string",
+      })
+      .option("startTime", {
+        describe: "start time to retrieve parts",
+        type: "number"
+      })
+      .option("endTime", {
+        describe: "end time to retrieve parts",
+        type: "number"
+      });
+  }
+}
+
+const script = new ObjectDownloadMedia();
+script.run();

--- a/testScripts/OfferingDownloadMedia.js
+++ b/testScripts/OfferingDownloadMedia.js
@@ -5,17 +5,20 @@ const Fraction = require("fraction.js");
 const {JSONPath} = require("jsonpath-plus");
 const fs = require("fs");
 const path = require("path");
+const { execSync } = require("child_process");
 
-class ObjectDownloadMedia extends ScriptBase {
+class OfferingDownloadMedia extends ScriptBase {
   async body() {
     const client = await this.client();
 
     let objectId = this.args.objectId;
-    const versionHash = this.args.objectHash;
-    const offeringType = this.args.offeringType || "default";
+    const versionHash = this.args.versionHash;
+    const offeringKey = this.args.offeringKey;
+    const streamKey = this.args.streamKey;
     const startTime = this.args.startTime;
     const endTime = this.args.endTime;
-    const out = this.args.out || "./out";
+    const out = this.args.out;
+
 
     if(objectId === undefined){
       if(versionHash===undefined){
@@ -26,7 +29,7 @@ class ObjectDownloadMedia extends ScriptBase {
     }
 
     const dirPath = path.resolve(out);
-    if (!fs.existsSync(dirPath)) {
+    if(!fs.existsSync(dirPath)) {
       fs.mkdirSync(dirPath, { recursive: true });
       console.log(`Directory created at ${dirPath}`);
     } else {
@@ -34,9 +37,9 @@ class ObjectDownloadMedia extends ScriptBase {
     }
 
 
-    const sourcesJsonPath = "offerings." + offeringType + ".media_struct.streams.video.sources[*]";
+    const sourcesJsonPath = "offerings." + offeringKey + ".media_struct.streams.video.sources[*]";
     const libraryId = await client.ContentObjectLibraryId({objectId, versionHash});
-    const totalDurationJsonPath = "offerings." + offeringType + ".media_struct.streams.video.duration";
+    const totalDurationJsonPath = "offerings." + offeringKey + ".media_struct.streams." + streamKey + ".duration";
 
     // get object metadata
     let metadata = await client.ContentObjectMetadata({
@@ -67,19 +70,22 @@ class ObjectDownloadMedia extends ScriptBase {
     if(startTime < 0 || endTime > totalDuration) {
       throw new Error(`start or end time provided are not within range: ${totalDuration}s`);
     }
+    if(startTime === endTime) {
+      throw new Error(`end time needs to be greater than start time, value provided: ${startTime}s`);
+    }
 
-    const sourcesTimeInfo = sourcesMetadata.map((item) => {
-      // start = item.timeline_start.ts * item.timeline_start.time_base
-      const startTimeBase = new Fraction(item.timeline_start.time_base);
-      const start = new Fraction(item.timeline_start.ts).mul(startTimeBase);
-      // end = item.timeline_start.ts * item.timeline_end.time_base
-      const endTimeBase = new Fraction(item.timeline_end.time_base);
-      const end = new Fraction(item.timeline_end.ts).mul(endTimeBase);
+    const sourcesTimeInfo = sourcesMetadata.map((part) => {
+      // start = part.timeline_start.ts * part.timeline_start.time_base
+      const startTimeBase = new Fraction(part.timeline_start.time_base);
+      const start = new Fraction(part.timeline_start.ts).mul(startTimeBase);
+      // end = part.timeline_start.ts * part.timeline_end.time_base
+      const endTimeBase = new Fraction(part.timeline_end.time_base);
+      const end = new Fraction(part.timeline_end.ts).mul(endTimeBase);
 
       return {
         start: start.valueOf(),
         end: end.valueOf(),
-        source: item.source
+        source: part.source
       };
     });
 
@@ -94,17 +100,43 @@ class ObjectDownloadMedia extends ScriptBase {
     console.log(parts);
     console.log();
 
+
+    let mtpath = path.join(dirPath, streamKey);
+    if(!fs.existsSync(mtpath)) {
+      fs.mkdirSync(mtpath, { recursive: true });
+      console.log(`Directory created at ${mtpath}`);
+    }
+    let partsfile = path.join(dirPath, "/parts_" + streamKey + ".txt");
+
     console.log("Downloading parts...");
     for(const partHash of parts) {
       console.log(partHash);
-      const arrayBuffer = await client.DownloadPart({
+      const buf = await client.DownloadPart({
         libraryId,
         objectId,
-        partHash
+        partHash,
+        format: "buffer",
+        chunked: false,
+        callback: ({bytesFinished, bytesTotal}) => {
+          console.log("  progress: ", bytesFinished + "/" + bytesTotal);
+        }
       });
-      let filePath = path.join(dirPath, partHash);
-      fs.writeFileSync(filePath, Buffer.from(arrayBuffer));
+
+      let partFile = path.join(mtpath, partHash + ".mp4");
+      fs.appendFile(partFile, buf, (err) => {
+        if(err)
+          console.log(err);
+      });
+      fs.appendFile(partsfile, "file '" + streamKey + "/" + partHash + ".mp4'\n", (err) => {
+        if(err)
+          console.log(err);
+      });
     }
+
+    // Concatenate parts into one mp4
+    let cmd = "ffmpeg -f concat -safe 0 -i " + partsfile + " -c copy " + dirPath + "/" + streamKey + ".mp4";
+    console.log("Running", cmd);
+    execSync(cmd);
   }
 
   header() {
@@ -118,29 +150,38 @@ class ObjectDownloadMedia extends ScriptBase {
         describe: "Object ID (should start with 'iq__')",
         type: "string"
       })
-      .option("objectHash", {
-        alias: "object-hash",
-        describe: "Object Hash (should start with 'hq__')",
+      .option("versionHash", {
+        alias: "version-hash",
+        describe: "Object Version Hash (should start with 'hq__')",
         type: "string"
       })
-      .option("offeringType", {
-        describe: "offerings type (default: 'default')",
+      .option("offeringKey", {
+        describe: "offering key",
         type: "string",
+        default: "default",
+      })
+      .option("streamKey", {
+        describe: "offerings stream key: audio/video",
+        type: "string",
+        default: "video",
       })
       .option("startTime", {
         describe: "start time to retrieve parts",
-        type: "number"
+        demandOption: true,
+        type: "number",
       })
       .option("endTime", {
         describe: "end time to retrieve parts",
-        type: "number"
+        demandOption: true,
+        type: "number",
       })
       .option("out",{
         describe: "output directory",
-        type: "string"
+        type: "string",
+        default: "./out",
       });
   }
 }
 
-const script = new ObjectDownloadMedia();
+const script = new OfferingDownloadMedia();
 script.run();

--- a/testScripts/OfferingDownloadMedia.js
+++ b/testScripts/OfferingDownloadMedia.js
@@ -164,24 +164,13 @@ class OfferingDownloadMedia extends ScriptBase {
       console.error("Error running ffmpeg:", error);
     }
 
-    // const secondsToHms=function(seconds, separator) {
-    //   const date=new Date(seconds * 1000);
-    //   const hh=String(date.getUTCHours()).padStart(2, "0");
-    //   const mm=String(date.getUTCMinutes()).padStart(2, "0");
-    //   const ss=String(date.getUTCSeconds()).padStart(2, "0");
-    //   const ms=String(date.getUTCMilliseconds()).padStart(3, "0");
-    //   return `${hh}${separator}${mm}${separator}${ss}.${ms}`;
-    // };
-
-    const secondsToHms = (seconds, separator = ":") => {
-      const totalSeconds = Math.floor(seconds);
-      const ms = Math.round((seconds - totalSeconds) * 1000);
-      const hh = String(Math.floor(totalSeconds / 3600)).padStart(2, "0");
-      const mm = String(Math.floor((totalSeconds % 3600) / 60)).padStart(2, "0");
-      const ss = String(totalSeconds % 60).padStart(2, "0");
-      const milliseconds = String(ms).padStart(3, "0");
-
-      return `${hh}${separator}${mm}${separator}${ss}.${milliseconds}`;
+    const secondsToHms=function(seconds, separator) {
+      const date=new Date(seconds * 1000);
+      const hh=String(date.getUTCHours()).padStart(2, "0");
+      const mm=String(date.getUTCMinutes()).padStart(2, "0");
+      const ss=String(date.getUTCSeconds()).padStart(2, "0");
+      const ms=String(date.getUTCMilliseconds()).padStart(3, "0");
+      return `${hh}${separator}${mm}${separator}${ss}.${ms}`;
     };
 
     let trimStartTime=null;

--- a/testScripts/OfferingDownloadMedia.js
+++ b/testScripts/OfferingDownloadMedia.js
@@ -109,8 +109,9 @@ class OfferingDownloadMedia extends ScriptBase {
     let partsfile = path.join(dirPath, "/parts_" + streamKey + ".txt");
 
     console.log("Downloading parts...");
-    for(const partHash of parts) {
-      console.log(partHash);
+    for(const [index, partHash] of parts.entries()){
+      let ph = (index+1).toString().padStart(4, "0") + "." + partHash;
+      console.log(`processing ${ph}...`);
       const buf = await client.DownloadPart({
         libraryId,
         objectId,
@@ -122,12 +123,12 @@ class OfferingDownloadMedia extends ScriptBase {
         }
       });
 
-      let partFile = path.join(mtpath, partHash + ".mp4");
+      let partFile = path.join(mtpath, ph + ".mp4");
       fs.appendFile(partFile, buf, (err) => {
         if(err)
           console.log(err);
       });
-      fs.appendFile(partsfile, "file '" + streamKey + "/" + partHash + ".mp4'\n", (err) => {
+      fs.appendFile(partsfile, "file '" + streamKey + "/" + ph + ".mp4'\n", (err) => {
         if(err)
           console.log(err);
       });

--- a/testScripts/OfferingDownloadMedia.js
+++ b/testScripts/OfferingDownloadMedia.js
@@ -185,7 +185,7 @@ class OfferingDownloadMedia extends ScriptBase {
 
     let trimmedOutputFile=path.join(dirPath, streamKey + "_" + secondsToHms(startTime, "-") + "_" + secondsToHms(endTime, "-") + ".mp4");
     // Trim the MP4 file to the specified start and end times
-    cmd=`ffmpeg -i ${path.join(dirPath, streamKey + ".mp4")} -ss ${secondsToHms(trimStartTime, ":")} -to ${secondsToHms(trimEndTime, ":")} -c copy ${trimmedOutputFile}`;
+    cmd=`ffmpeg -i ${path.join(dirPath, streamKey + ".mp4")} -ss ${secondsToHms(trimStartTime, ":")} -to ${secondsToHms(trimEndTime, ":")} ${trimmedOutputFile}`;
     console.log("Running", cmd);
     try {
       execSync(cmd);

--- a/testScripts/OfferingDownloadMedia.js
+++ b/testScripts/OfferingDownloadMedia.js
@@ -164,13 +164,24 @@ class OfferingDownloadMedia extends ScriptBase {
       console.error("Error running ffmpeg:", error);
     }
 
-    const secondsToHms=function(seconds, separator) {
-      const date=new Date(seconds * 1000);
-      const hh=String(date.getUTCHours()).padStart(2, "0");
-      const mm=String(date.getUTCMinutes()).padStart(2, "0");
-      const ss=String(date.getUTCSeconds()).padStart(2, "0");
-      const ms=String(date.getUTCMilliseconds()).padStart(3, "0");
-      return `${hh}${separator}${mm}${separator}${ss}.${ms}`;
+    // const secondsToHms=function(seconds, separator) {
+    //   const date=new Date(seconds * 1000);
+    //   const hh=String(date.getUTCHours()).padStart(2, "0");
+    //   const mm=String(date.getUTCMinutes()).padStart(2, "0");
+    //   const ss=String(date.getUTCSeconds()).padStart(2, "0");
+    //   const ms=String(date.getUTCMilliseconds()).padStart(3, "0");
+    //   return `${hh}${separator}${mm}${separator}${ss}.${ms}`;
+    // };
+
+    const secondsToHms = (seconds, separator = ":") => {
+      const totalSeconds = Math.floor(seconds);
+      const ms = Math.round((seconds - totalSeconds) * 1000);
+      const hh = String(Math.floor(totalSeconds / 3600)).padStart(2, "0");
+      const mm = String(Math.floor((totalSeconds % 3600) / 60)).padStart(2, "0");
+      const ss = String(totalSeconds % 60).padStart(2, "0");
+      const milliseconds = String(ms).padStart(3, "0");
+
+      return `${hh}${separator}${mm}${separator}${ss}.${milliseconds}`;
     };
 
     let trimStartTime=null;
@@ -189,7 +200,8 @@ class OfferingDownloadMedia extends ScriptBase {
     console.log("Running", cmd);
     try {
       execSync(cmd);
-      console.log(`Trimmed file: ${trimmedOutputFile}`);
+      console.log(`\nTrimmed file: ${trimmedOutputFile}`);
+      console.log(`Duration of MP4 file: ${trimDuration}s`);
     } catch(error) {
       console.error("Error running ffmpeg:", error);
     }

--- a/testScripts/OfferingDownloadMedia.js
+++ b/testScripts/OfferingDownloadMedia.js
@@ -86,9 +86,12 @@ class OfferingDownloadMedia2 extends ScriptBase {
     }
     // create directory for object provided : iq_XXX_start-time_end-time
     const contentObjDirPath = path.join(dirPath, `${objectId}_${this.secondsToHms(startTime, "-")}_${this.secondsToHms(endTime, "-")}`);
-    if(fs.existsSync(contentObjDirPath)) throw new Error(`Directory already exists at ${contentObjDirPath}`);
-    fs.mkdirSync(contentObjDirPath, { recursive: true });
-    console.log(`Directory created at ${contentObjDirPath}`);
+    // if(fs.existsSync(contentObjDirPath)) throw new Error(`Directory already exists at ${contentObjDirPath}`);
+    // fs.mkdirSync(contentObjDirPath, { recursive: true });
+    if(!fs.existsSync(contentObjDirPath)) {
+      fs.mkdirSync(contentObjDirPath, { recursive: true });
+      console.log(`Directory created at ${contentObjDirPath}`);
+    }
 
     const trimmedDirectory = path.join(contentObjDirPath, "trimmed");
     if(!fs.existsSync(trimmedDirectory)) {
@@ -191,12 +194,14 @@ class OfferingDownloadMedia2 extends ScriptBase {
   }
 
   async downloadParts(outDir, libraryId, objectId, streamKey, parts) {
-
     const mtPath=path.join(outDir, streamKey);
     if(!fs.existsSync(mtPath)) {
       fs.mkdirSync(mtPath, {recursive: true});
       console.log(`Directory created at ${mtPath}`);
+    } else {
+      throw new Error(`Directory already exists at ${mtPath}`);
     }
+
     const partsFile=path.join(outDir, `parts_${streamKey}.txt`);
     const client=await this.client();
 

--- a/testScripts/OfferingDownloadMedia.js
+++ b/testScripts/OfferingDownloadMedia.js
@@ -90,6 +90,11 @@ class OfferingDownloadMedia2 extends ScriptBase {
     fs.mkdirSync(contentObjDirPath, { recursive: true });
     console.log(`Directory created at ${contentObjDirPath}`);
 
+    const trimmedDirectory = path.join(contentObjDirPath, "trimmed");
+    if(!fs.existsSync(trimmedDirectory)) {
+      fs.mkdirSync(trimmedDirectory, { recursive: true });
+    }
+
     // Download and concatenate the parts for each streamKey
     // Then, trim the concatenated media
     for(const streamKey of Object.keys(partsMap)) {
@@ -117,7 +122,7 @@ class OfferingDownloadMedia2 extends ScriptBase {
         trimEndTime=endTime - minStart;
       }
 
-      let mediaTrimmedFile=path.join(contentObjDirPath, `${streamKey}_trimmed.mp4`);
+      let mediaTrimmedFile=path.join(trimmedDirectory, `${streamKey}_trimmed.mp4`);
       cmd=`ffmpeg -i ${mediaFile} -ss ${this.secondsToHms(trimStartTime, ":")} -t ${this.secondsToHms(trimEndTime - trimStartTime, ":")} ${mediaTrimmedFile}`;
       console.log("Running", cmd);
       try {


### PR DESCRIPTION
The script `OfferingDownloadMedia` performs the following:
* Retrieves streams metadata from either `transcodes` or `offerings` for each provided streamKey.
* Then downloads the parts, concatenates them, and trims the media file for each streamKey.

### Steps:
* export PRIVATE_KEY="xxx"
* set demov3 network in TestConfiguration.json or using --config-url
* Run the command:
```
node ./testScripts/OfferingDownloadMedia.js 
--startTime 10 
--endTime 50 
--objectId=iq__bSS84FakdSgxHSiW3kJcA1obH6P 
--out ./out_dir 
--config-url "https://demov3.net955210.contentfabric.io/config"
--streamKey "video,polish_5_1,english_stereo"
```

* For each content with a startTime and endTime, a new folder will be created under the output directory, as shown below:
```
./out_dir
└── iq__bSS84FakdSgxHSiW3kJcA1obH6P_00-00-40.500_00-01-10.000
    ├── english_stereo
    │   ├── 0001.hqpeBJhFb8U8gedQRc1gPT4uKd6fxawWmQBUjRcQuiRT2TKp1hVZ.mp4
    │   └── 0002.hqpe4oNGvobdiDeX9r9RnTAqtESNjKqtxryUAx51JhMxuhh4fUFq.mp4
    ├── english_stereo.mp4
    ├── parts_english_stereo.txt
    ├── parts_polish_5_1.txt
    ├── parts_video.txt
    ├── polish_5_1
    │   ├── 0001.hqpeNjNmLQvLQxfx3hWvXZzJ4nv2hF41DdrzSefRxxBDVRLyCsZ7.mp4
    │   └── 0002.hqpe6iHZFyZ7qroTSfz6xiVrhtDRyYktLveofuE27NB8EaXGtfCh.mp4
    ├── polish_5_1.mp4
    ├── trimmed
    │   ├── english_stereo_trimmed.mp4
    │   ├── polish_5_1_trimmed.mp4
    │   └── video_trimmed.mp4
    ├── video
    │   ├── 0001.hqpedi3ftDawHChtviNtzCbcVsnVukpjbqm6bmM1TaPJRutgz8x3Q.mp4
    │   └── 0002.hqpe2tXuAapeuTdPFNcwqnJFKyV1RxbVqz4Jc3ejJtn5iYURQDjeWS.mp4
    └── video.mp4

5 directories, 15 files

```

For instance, for `english_stereo` streamKey:
`english_stereo` folder => contains all the parts that fall within the start and end times.
`english_stereo.mp4` => the concatenated file
`english_stereo_trimeed.mp4` => this file has been both concatenated and trimmed to the specified time range.


### Command usage:
```
 node ./testScripts/OfferingDownloadMedia --help
Options:
  --help                         Show help                                                                                                                                                       [boolean]
  --debug                        Print debug logging for API calls                                                                                                                               [boolean]
  --configUrl, --config-url      URL pointing to the Fabric configuration, enclosed in quotes. e.g. for Eluvio demo network: --configUrl "https://demov3.net955210.contentfabric.io/config"       [string]
  --elvGeo, --elv-geo            Geographic region for the fabric nodes.                       [string] [choices: "as-east", "au-east", "eu-east", "eu-west", "na-east", "na-west-north", "na-west-south"]
  --objectId, --object-id        Object ID (should start with 'iq__')                                                                                                                             [string]
  --versionHash, --version-hash  Object Version Hash (should start with 'hq__')                                                                                                                   [string]
  --offeringKey                  offering key                                                                                                                                [string] [default: "default"]
  --streamKey                    comma separated list of offerings stream key                                                                                                  [string] [default: "video"]
  --startTime                    start time to retrieve parts in seconds                                                                                                               [number] [required]
  --endTime                      end time to retrieve parts in seconds                                                                                                                 [number] [required]
  --out                          output directory                                   
```