### PR TITLE
Allow StreamConfig connection_timeout setting

### DIFF
--- a/src/client/LiveConf.js
+++ b/src/client/LiveConf.js
@@ -455,6 +455,10 @@ class LiveConf {
       conf.live_recording.recording_config.recording_params.part_ttl = customSettings.part_ttl;
     }
 
+    if(customSettings.connection_timeout) {
+      conf.live_recording.recording_config.recording_params.xc_params.connection_timeout = customSettings.connection_timeout;
+    }
+
     // Fill in specifics for protocol
     switch(this.probeKind()) {
       case "udp":


### PR DESCRIPTION
Allow connection_timeout setting during StreamConfig to avoid overriding with the LiveConf default.