### PR TITLE
Fix check for 'write token not found' in ContentAccessMetadata()

### DIFF
--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -932,7 +932,7 @@ exports.ContentObjectMetadata = async function({
       throw error;
     }
     // For a 404 error, check if error was due to write token not found
-    const errQwtoken = objectPath.get(error.body, "errors[0].cause.cause.cause.qwtoken");
+    const errQwtoken = objectPath.get(error.body, "errors.0.cause.cause.cause.qwtoken");
     if(errQwtoken) {
       // if so, re-throw rather than suppress error
       throw error;


### PR DESCRIPTION
I previously used wrong path syntax in the call to objectPath.get(), failing to detect when cause of error was 'write token not found' (as opposed to the requested path not existing in the metadata). 

This resulted in `{}` getting returned instead of throwing an error.

Intended behavior was to throw an error if the node could not find the write token.