### PR TITLE
Add support for ignoreBitrateLimit in mez finalize, add calls to look up node info and URL for write token

### DIFF
--- a/src/client/ABRPublishing.js
+++ b/src/client/ABRPublishing.js
@@ -641,12 +641,13 @@ exports.LROStatus = async function({libraryId, objectId}) {
  * @param {string} libraryId - ID of the mezzanine library
  * @param {string} objectId - ID of the mezzanine object
  * @param {string} writeToken - Write token for the mezzanine object
+ * @param {boolean=} ignoreBitrateLimit - Finalize even if transcoded stream's bitrate greatly exceeds target rate
  * @param {function=} preFinalizeFn - A function to call before finalizing changes, to allow further modifications to offering. The function will be invoked with {elvClient, nodeUrl, writeToken} to allow access to the draft and MUST NOT finalize the draft.
  * @param {boolean=} preFinalizeThrow - If set to `true` then any error thrown by preFinalizeFn will not be caught. Otherwise, any exception will be appended to the `warnings` array returned after finalization.
  *
  * @return {Promise<Object>} - The finalize response for the mezzanine object, as well as any logs, warnings and errors from the finalization
  */
-exports.FinalizeABRMezzanine = async function({libraryId, objectId, preFinalizeFn, preFinalizeThrow}) {
+exports.FinalizeABRMezzanine = async function({libraryId, objectId, ignoreBitrateLimit, preFinalizeFn, preFinalizeThrow}) {
   ValidateParameters({libraryId, objectId});
 
   const lroDraft = await this.LRODraftInfo({libraryId, objectId});
@@ -680,7 +681,8 @@ exports.FinalizeABRMezzanine = async function({libraryId, objectId, preFinalizeF
     writeToken: lroDraft.write_token,
     method: UrlJoin("media", "abr_mezzanine", "offerings", offeringKey, "finalize"),
     headers,
-    constant: false
+    constant: false,
+    body: {ignoreBitrateLimit}
   });
 
   let preFinalizeWarnings = [];

--- a/utilities/WriteTokenDecode.js
+++ b/utilities/WriteTokenDecode.js
@@ -1,27 +1,41 @@
 // Retrieve part list from object
 const Utility = require("./lib/Utility");
 
+const Client = require("./lib/concerns/Client");
 const Draft = require("./lib/concerns/Draft");
 const {NewOpt} = require("./lib/options");
 
 class WriteTokenDecode extends Utility {
   blueprint() {
     return {
-      concerns: [Draft],
+      concerns: [Client, Draft],
       options: [
         NewOpt("writeToken", {
           demand: true,
           descTemplate: "Write token to decode",
           type: "string"
+        }),
+        NewOpt("node", {
+          descTemplate: "Look up node info",
+          type: "boolean"
         })
       ]
     };
   }
 
   async body() {
-    const {writeToken} = this.args;
+    const {writeToken, node} = this.args;
+    const tokenInfo = this.concerns.Draft.decode({writeToken});
+    let result = {};
+    if(node) {
+      const client = await this.concerns.Client.get();
+      const nodeInfo = await client.WriteTokenNodeInfo({writeToken});
+      result = {tokenInfo, nodeInfo};
+    } else {
+      result = {tokenInfo};
+    }
     // eslint-disable-next-line no-console
-    console.log(JSON.stringify(this.concerns.Draft.decode({writeToken}), null, 2));
+    console.log(JSON.stringify(result, null,2));
   }
 
   header() {


### PR DESCRIPTION
Content Fabric server is adding a new POST body field `ignore_bitrate_limit` to `abr_mezzanine/offerings/OFFERING_KEY/finalize` API call. This PR plumbs this field through as parameter to function `ElvClient. FinalizeABRMezzanine()`

It also adds functions `ElvClient. WriteTokenNodeInfo()` and `ElvClient. WriteTokenNodeURL()` to quickly lookup node info/URL for a write token using the (relatively) new node list API call. (Previously this required a slow process of iterating through node list and making Ethereum calls for each)

 * Add support for `ignoreBitrateLimit` option to `FinalizeABRMezzanine()`
 * Add calls `WriteTokenNodeInfo()` and `WriteTokenNodeURL()`
 * Add `--node` option to `utilities/WriteTokenDecode.js` to look up node info