### PR TITLE
add optional args to GenerateFabricToken

### DIFF
--- a/utilities/GenerateFabricToken.js
+++ b/utilities/GenerateFabricToken.js
@@ -2,7 +2,7 @@ const { ElvClient } = require("../src/ElvClient");
 
 const GenerateFabricToken = async () => {
   try {
-    const client = await ElvClient.FromNetworkName({networkName: "main"});
+    const client = await ElvClient.FromNetworkName({networkName: process.env.ENV ?? "main"});
 
     const wallet = client.GenerateWallet();
     const signer = wallet.AddAccount({
@@ -12,7 +12,8 @@ const GenerateFabricToken = async () => {
     client.SetSigner({signer});
 
     console.log(await client.CreateFabricToken({
-      duration: parseInt(process.env.DURATION),
+      duration: parseInt(process.env.DURATION ?? 24 * 60 * 60 * 1000),
+      context:  JSON.parse(process.env.ELV_TOK_CTX ?? "{}")
       //context: {email:"xyz@eluv.io"}
     }));
   } catch(error) {


### PR DESCRIPTION
I use this when swapping between private keys to put a token in my env for curl dev use; need the ENV part.  and for convenience use the ctx part so it's easy to set some info for elv tools decode.


