### PR TITLE
Fix handling of undefined `options.createKMSConk` in `CreateContentObject()`

### DIFF
--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -632,7 +632,7 @@ exports.CreateContentObject = async function({libraryId, objectId, options={}}) 
       libraryId,
       objectId,
       writeToken: createResponse.write_token,
-      createKMSConk: options.createKMSConk
+      createKMSConk: !!options.createKMSConk // make sure `undefined` gets converted to `false`
     }
   );
 


### PR DESCRIPTION
When `options.createKMSConk===undefined`  this value was getting overridden by default `true` in cases where `CreateContentObject()` calls `CreateEncryptionConk()`