### PR TITLE
Write to writeToken for watermark config

### DIFF
--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -2026,7 +2026,7 @@ exports.StreamAddWatermark = async function({
     await this.ReplaceMetadata({
       libraryId,
       objectId,
-      writeToken: edgeWriteToken,
+      writeToken: writeToken,
       metadataSubtree: metadataPath,
       metadata: objectMetadata
     });


### PR DESCRIPTION
Saving a watermark fails when attempting to write to edge write token instead of write token.