### PR TITLE
Object cleanup and Test fixes

### DIFF
--- a/src/client/Contracts.js
+++ b/src/client/Contracts.js
@@ -947,8 +947,20 @@ const ObjectTypesToClean = Object.freeze({
 });
 
 /**
- * Cleans up objects (libraries, content objects, groups or content types)
- * associated with a given user or object
+ * Cleans up deleted objects pointed to by the access index of a given "access group" or "user wallet"
+ * Contracts of type "access group" and "user wallet" contain an "access index" - a list of objects that they have access to.
+ *
+ * There are 4 specific indexes, one for each object type:
+ * - content
+ * - library
+ * - access groups
+ * - content types
+ *
+ * If an object gets deleted and the access index still points to it, it will cause errors in API calls for the access
+ * group or user wallet.
+ *
+ * This function checks each index for objects that are deleted, and removes them from the index (either all indexes or
+ * just the one specified by parameter 'objectTypeToClean')
  *
  * For user, the cleanup is performed on the user wallet and on all its access group
  *

--- a/test/ElvClient.test.js
+++ b/test/ElvClient.test.js
@@ -2960,13 +2960,20 @@ describe("Test ElvClient", () => {
         expect(undefined).toBeDefined();
         // eslint-disable-next-line no-empty
       } catch(error) {}
+    });
 
+    test("Object Cleanup", async () => {
       let contractAddress = client.signer.address;
-      let res = await client.ObjectCleanup({contractAddress, objectTypeToClean: "content_object"});
+      const res = await client.ObjectCleanup({contractAddress, objectTypeToClean: "content_object"});
       expect(res).toBeDefined();
-      expect(res.beforeCleanup.contentObjectsLength).toBeDefined();
-      expect(res.afterCleanup.contentObjectsLength).toBeDefined();
-      expect(res.afterCleanup.contentObjectsLength).toBeLessThan(res.beforeCleanup.contentObjectsLength);
+      expect(res[contractAddress]).toBeDefined();
+
+      const resForSigner = res[contractAddress];
+      expect(resForSigner.beforeCleanup.contentObjectsLength).toBeDefined();
+      expect(resForSigner.afterCleanup.contentObjectsLength).toBeDefined();
+      const beforeCleanup = resForSigner.beforeCleanup.contentObjectsLength;
+      const afterCleanup = resForSigner.afterCleanup.contentObjectsLength;
+      expect(afterCleanup).toBeLessThan(beforeCleanup);
     });
 
     test("Clear Tenancy", async () => {

--- a/test/ElvClient.test.js
+++ b/test/ElvClient.test.js
@@ -2916,9 +2916,6 @@ describe("Test ElvClient", () => {
     });
 
     test("Delete Content Object", async () => {
-      let res1 = await client.ContentObject({libraryId, objectId});
-      console.log("OBJECT EXISTS", JSON.stringify(res1));
-
       // Delete test object
       await client.DeleteContentObject({libraryId, objectId});
 
@@ -2929,10 +2926,6 @@ describe("Test ElvClient", () => {
         expect(undefined).toBeDefined();
         // eslint-disable-next-line no-empty
       } catch(error) {}
-
-      let contractAddress = client.signer.address;
-      let res = await client.ObjectCleanup({contractAddress, objectTypeToClean: "content_object"});
-      console.log("RES", JSON.stringify(res, " ", 2));
 
       // Delete master
       await client.DeleteContentObject({libraryId: mediaLibraryId, objectId: masterId});
@@ -2968,9 +2961,12 @@ describe("Test ElvClient", () => {
         // eslint-disable-next-line no-empty
       } catch(error) {}
 
-      contractAddress = client.userProfileClient.signer.address.toString();
-      res = await client.ObjectCleanup({contractAddress, objectTypeToClean: "content_object"});
-      console.log("RES", JSON.stringify(res, " ", 2));
+      let contractAddress = client.signer.address;
+      let res = await client.ObjectCleanup({contractAddress, objectTypeToClean: "content_object"});
+      expect(res).toBeDefined();
+      expect(res.beforeCleanup.contentObjectsLength).toBeDefined();
+      expect(res.afterCleanup.contentObjectsLength).toBeDefined();
+      expect(res.afterCleanup.contentObjectsLength).toBeLessThan(res.beforeCleanup.contentObjectsLength);
     });
 
     test("Clear Tenancy", async () => {

--- a/test/ElvClient.test.js
+++ b/test/ElvClient.test.js
@@ -388,7 +388,9 @@ describe("Test ElvClient", () => {
   describe("Content Libraries", () => {
 
     test("Set Tenant ID For User",async () => {
-      await client.userProfileClient.SetTenantId({address: tenantAdminAddress});
+      await client.userProfileClient.SetTenantContractId({tenantContractId});
+      //await client.userProfileClient.SetTenantId({address: tenantAdminAddress});
+      expect(client.userProfileClient.tenantContractId).toEqual(tenantContractId);
       expect(client.userProfileClient.tenantId).toEqual(tenantId);
     });
 
@@ -575,18 +577,18 @@ describe("Test ElvClient", () => {
       await expect(finalizeResponse).toBeDefined();
 
       const metadata = await client.ContentObjectMetadata({libraryId, objectId});
-      delete metadata.commit;
+      //delete metadata.commit;
 
-      expect(metadata).toEqual(testMetadata);
+      expect(metadata).toMatchObject(testMetadata);
 
       versionHash = finalizeResponse.hash;
     });
 
     test("Content Object Metadata", async () => {
       const metadata = await client.ContentObjectMetadata({libraryId, objectId});
-      delete metadata.commit;
+      //delete metadata.commit;
 
-      expect(metadata).toEqual({
+      expect(metadata).toMatchObject({
         name: "Test Content Object",
         toMerge: {
           merge: "me"
@@ -654,7 +656,7 @@ describe("Test ElvClient", () => {
       const metadata = await client.ContentObjectMetadata({libraryId, objectId});
       delete metadata.commit;
 
-      expect(metadata).toEqual({
+      expect(metadata).toMatchObject({
         name: "Test Content Object",
         toMerge: {
           new: "metadata",
@@ -718,7 +720,8 @@ describe("Test ElvClient", () => {
 
       expect(unfiltered).toBeDefined();
       expect(unfiltered.contents).toBeDefined();
-      expect(unfiltered.contents.length).toEqual(5);
+      // object for library + 5 content objects
+      expect(unfiltered.contents.length).toEqual(6);
       expect(unfiltered.paging).toBeDefined();
 
       /* Sorting */
@@ -847,7 +850,7 @@ describe("Test ElvClient", () => {
 
       expect(automaticCommit).toBeDefined();
       if(isUsingExternalTenantContractId){
-        expect(automaticCommit.author).toContain("tenant-elv-admin");
+        expect(automaticCommit.author).toContain("elv-admin");
       } else {
         expect(client.utils.EqualAddress(automaticCommit.author, automaticCommit.author_address)).toBeTruthy();
       }
@@ -878,7 +881,7 @@ describe("Test ElvClient", () => {
 
       expect(customCommit).toBeDefined();
       if(isUsingExternalTenantContractId){
-        expect(customCommit.author).toContain("tenant-elv-admin");
+        expect(customCommit.author).toContain("elv-admin");
       } else {
         expect(client.utils.EqualAddress(customCommit.author, customCommit.author_address)).toBeTruthy();
       }
@@ -2955,6 +2958,10 @@ describe("Test ElvClient", () => {
         expect(undefined).toBeDefined();
         // eslint-disable-next-line no-empty
       } catch(error) {}
+
+      let contractAddress = client.userProfileClient.signer.address.toString();
+      let res = await client.ObjectCleanup({contractAddress, objectTypeToClean: "content_object"});
+      console.log("RES", JSON.stringify(res, " ", 2));
     });
 
     test("Clear Tenancy", async () => {


### PR DESCRIPTION
## Changes made:

To address: https://github.com/qluvio/content-fabric/issues/3317

### ObjectCleanup:
  The `ObjectCleanup` method addresses an issue where the deleted objects continued to appear in the user listings due to references in the `access_indexor` contract. It removes entries for deleted objects so that they no longer appear in Frowser post-cleanup.

* It accepts:
   * Object ID, version hash, or contract address (can be user address or contract)
   * Object type: "library", "content_object", "group", "content_type", or "all"

* When a **user address** is provided, it performs cleanup for the user and all associated groups concurrently.
* Example output:
```json
{
  "0xC9f6BF00aBb5CCD35116760D2A0a5E64b617B84c": {
    "beforeCleanup": {
      "contentObjectsLength": 324
    },
    "afterCleanup": {
      "contentObjectsLength": 323
    }
  },
  "groups": {
    "0x100a5E0BAD86b23e5Ba9Ff4327cd1Ff8e8159ec0": {
      "beforeCleanup": {
        "contentObjectsLength": 15
      },
      "afterCleanup": {
        "contentObjectsLength": 15
      }
    },
    "0x586626b981046aF729502454b2C866f4D366E0e1": {
      "beforeCleanup": {
        "contentObjectsLength": 44
      },
      "afterCleanup": {
        "contentObjectsLength": 44
      }
    }
}
```

### Test Suite Improvements:

 Cleaned up some of the failing test in `ElvClient`:

In dv3,
Before:
```
== Test Suite ElvClient Finished in 1165.3s: 67 Passed, 21 Failed, 6 Skipped ==
```
After:
```
== Test Suite ElvClient Finished in 1234.7s: 79 Passed, 10 Failed, 6 Skipped ==
```
All tests results:
```
==== All test suites finished in 1886.7s: 131 Passed, 12 Failed, 7 Skipped ====
```
