### PR TITLE
Stream single wt

### DIFF
--- a/src/client/ABRPublishing.js
+++ b/src/client/ABRPublishing.js
@@ -323,7 +323,7 @@ exports.CreateABRMezzanine = async function({
     // determine master object id if a master write token was passed in
     ValidateWriteToken(masterWriteToken);
     masterObjectId = this.utils.DecodeWriteToken(masterWriteToken).objectId;
-    masterLibId = await client.ContentObjectLibraryId({masterObjectId});
+    masterLibId = await client.ContentObjectLibraryId({objectId: masterObjectId});
   }
 
   // if pre-existing mez object id passed in, validate


### PR DESCRIPTION
Add support for `writeToken` and `finalize` to `StreamInitialize` and subsequent functions to allow changing DRM configuration with a single write token.
Relates to: https://github.com/eluv-io/elv-live-stream/issues/90