### PR TITLE
Move protocol/DRM filter check before playoutMap in PlayoutOptions

### DIFF
--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -1495,6 +1495,13 @@ exports.PlayoutOptions = async function({
     const cert = option.properties.cert;
     const thumbnailTrackUri = option.properties.thumbnails_webvtt_uri;
 
+    // Exclude any options that do not satisfy the specified protocols and/or DRMs
+    const protocolMatch = protocols.includes(protocol);
+    const drmMatch = drms.includes(drm || "clear") || (drms.length === 0 && !drm);
+    if(!protocolMatch || !drmMatch) {
+      continue;
+    }
+
     if(hlsjsProfile && protocol === "hls" && drm === "aes-128") {
       queryParams.player_profile = "hls-js";
     }
@@ -1558,13 +1565,6 @@ exports.PlayoutOptions = async function({
         certUrl.pathname = certUrl.pathname.split("/").slice(0,-1).concat(["drm.cert"]).join("/");
         playoutMap[protocol].playoutMethods[method].drms[drm].cert_url = certUrl.toString();
       }
-    }
-
-    // Exclude any options that do not satisfy the specified protocols and/or DRMs
-    const protocolMatch = protocols.includes(protocol);
-    const drmMatch = drms.includes(drm || "clear") || (drms.length === 0 && !drm);
-    if(!protocolMatch || !drmMatch) {
-      continue;
     }
 
     // This protocol / DRM satisfies the specifications (prefer DRM over clear, if available)

--- a/test/ElvClient.test.js
+++ b/test/ElvClient.test.js
@@ -2172,6 +2172,28 @@ describe("Test ElvClient", () => {
       };
     });
 
+    test("Playout Options Protocol Filter", async () => {
+      const hlsOnly = await accessClient.PlayoutOptions({
+        objectId: mezzanineId,
+        protocols: ["hls"],
+        drms: []
+      });
+
+      expect(hlsOnly.hls).toBeDefined();
+      expect(hlsOnly.hls.playoutUrl).toBeDefined();
+      expect(hlsOnly.dash).toBeUndefined();
+
+      const dashOnly = await accessClient.PlayoutOptions({
+        objectId: mezzanineId,
+        protocols: ["dash"],
+        drms: []
+      });
+
+      expect(dashOnly.dash).toBeDefined();
+      expect(dashOnly.dash.playoutUrl).toBeDefined();
+      expect(dashOnly.hls).toBeUndefined();
+    });
+
     test("Playout Options From Self Link", async () => {
       try {
         // Create a link to default playout

--- a/testScripts/PlayoutOptions.js
+++ b/testScripts/PlayoutOptions.js
@@ -1,0 +1,86 @@
+const { ElvClient } = require("../src/ElvClient");
+const yargs = require("yargs");
+
+
+// PRIVATE_KEY="xxx" node testScripts/PlayoutOptions.js --objectId iq__... \
+// --protocols hls,dash \
+// --drms fairplay,widevine,playready,aes-128,sample-aes,clear \
+// --config-url XXX
+const argv = yargs
+  .option("objectId", {
+    description: "Object ID of the content"
+  })
+  .option("versionHash", {
+    description: "Version hash of the content"
+  })
+  .option("offering", {
+    description: "Offering key",
+    default: "default"
+  })
+  .option("protocols", {
+    description: "Comma-separated list of protocols (hls, dash)",
+    default: "hls,dash"
+  })
+  .option("drms", {
+    description: "Comma-separated list of DRMs (aes-128, fairplay, widevine, playready, sample-aes, clear). Leave empty for clear.",
+    default: ""
+  })
+  .option("config-url", {
+    type: "string",
+    description: "URL pointing to the Fabric configuration. i.e. https://main.net955210.contentfabric.io/config"
+  })
+  .option("debug", {
+    type: "boolean",
+    description: "Enable client logging"
+  })
+  .check(argv => {
+    if(!argv.objectId && !argv.versionHash) {
+      throw new Error("Either --objectId or --versionHash must be specified");
+    }
+    return true;
+  })
+  .strict().argv;
+
+const ClientConfiguration = (!argv["config-url"]) ? (require("../TestConfiguration.json")) : {"config-url": argv["config-url"]};
+
+const Run = async () => {
+  const privateKey = process.env.PRIVATE_KEY;
+  if(!privateKey) {
+    console.error("PRIVATE_KEY environment variable must be specified");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const client = await ElvClient.FromConfigurationUrl({
+      configUrl: ClientConfiguration["config-url"]
+    });
+
+    const wallet = client.GenerateWallet();
+    const signer = wallet.AddAccount({privateKey});
+    await client.SetSigner({signer});
+
+    if(argv.debug) {
+      client.ToggleLogging(true);
+    }
+
+    const protocols = argv.protocols.split(",").map(p => p.trim()).filter(Boolean);
+    const drms = argv.drms ? argv.drms.split(",").map(d => d.trim()).filter(Boolean) : [];
+
+    const playoutOptions = await client.PlayoutOptions({
+      objectId: argv.objectId,
+      versionHash: argv.versionHash,
+      offering: argv.offering,
+      protocols,
+      drms
+    });
+
+    console.log(JSON.stringify(playoutOptions, null, 2));
+  } catch(error) {
+    console.error("Error getting playout options:");
+    console.error(error.body ? JSON.stringify(error, null, 2) : error);
+    process.exitCode = 1;
+  }
+};
+
+Run();


### PR DESCRIPTION
Fix moves the protocolMatch/drmMatch check to the top of the loop so non-matching options are skipped entirely before any URL generation or map changes.

Test: Added `Playout Options Protocol Filter` - requests only hls and verifies dash is absent and vice versa.