### PR TITLE
Revert "remote-signer decrypt + pubkey (#363)"

### DIFF
--- a/src/ElvClient.js
+++ b/src/ElvClient.js
@@ -1348,9 +1348,7 @@ class ElvClient {
 
     ValidatePresence("message", message);
 
-    return this.signer.remoteSigner ?
-      await this.signer.DecryptCap(message) :
-      await this.Crypto.DecryptCap(message, this.signer._signingKey().privateKey);
+    return await this.Crypto.DecryptCap(message, this.signer._signingKey().privateKey);
   }
 
   /**

--- a/src/RemoteSigner.js
+++ b/src/RemoteSigner.js
@@ -47,7 +47,7 @@ class RemoteSigner extends Ethers.Signer {
         body.code = this.userIdCode;
       }
 
-      const {addr, eth, token, pubkey} = await Utils.ResponseToJson(
+      const {addr, eth, token} = await Utils.ResponseToJson(
         this.HttpClient.Request({
           path: UrlJoin("as", "wlt", "login", this.userIdCode ? "code" : "jwt"),
           method: "POST",
@@ -61,10 +61,9 @@ class RemoteSigner extends Ethers.Signer {
       this.authToken = token;
       this.address = Utils.FormatAddress(addr);
       this.id = eth;
-      this.publicKey = pubkey;
     }
 
-    if(!this.address || !this.publicKey) {
+    if(!this.address) {
       const keys = await Utils.ResponseToJson(
         this.HttpClient.Request({
           method: "GET",
@@ -75,18 +74,12 @@ class RemoteSigner extends Ethers.Signer {
         })
       );
 
-      if(!this.address) {
-        const address = keys.eth[0];
+      const address = keys.eth[0];
 
-        if(address && address.startsWith("0x")) {
-          this.address = address;
-        } else {
-          this.address = Utils.HashToAddress(keys.eth[0]);
-        }
-      }
-
-      if(!this.publicKey) {
-        this.publicKey = keys.pubkey && keys.pubkey[0];
+      if(address && address.startsWith("0x")) {
+        this.address = address;
+      } else {
+        this.address = Utils.HashToAddress(keys.eth[0]);
       }
     }
 
@@ -175,63 +168,6 @@ class RemoteSigner extends Ethers.Signer {
 
   getAddress() {
     return this.address;
-  }
-
-  _normalizePublicKey(key) {
-    const with0x = key.startsWith("0x") ? key : `0x${key}`;
-    return with0x.length === 2 + 128 ? `0x04${with0x.slice(2)}` : with0x;
-  }
-
-  /**
-   * This signer's public key, as provided by the authd service
-   *
-   * @return {Promise<string>} - The public key, in uncompressed hex like SigningKey.publicKey
-   */
-  async PublicKey() {
-    if(!this.publicKey) {
-      throw Error("RemoteSigner: public key not available - call Initialize() first");
-    }
-
-    return this._normalizePublicKey(this.publicKey);
-  }
-
-  /** so remote signers can be used interchangeably with local signers */
-  _signingKey() {
-    if(!this.publicKey) {
-      throw Error("RemoteSigner: public key not available - call Initialize() first");
-    }
-
-    const publicKey = this._normalizePublicKey(this.publicKey);
-    return {
-      publicKey,
-      get privateKey() {
-        throw Error("RemoteSigner: remote signer does not have direct access to a private key");
-      }
-    };
-  }
-
-  /**
-   * Decrypt a secp256k1 ECIES-encrypted blob (e.g. a fabric encryption conk) that was wrapped
-   * for this signer's public key, via the authd service's generic decrypt endpoint.
-   *
-   * @param {string} encryptedData - Base64-encoded ECIES-encrypted blob
-   * @return {Promise<Object>} - The decrypted, JSON-parsed contents
-   */
-  async DecryptCap(encryptedData) {
-    const {data} = await Utils.ResponseToJson(
-      this.HttpClient.Request({
-        method: "POST",
-        path: UrlJoin("as", "wlt", "decrypt", "eth", this.id),
-        headers: {
-          Authorization: `Bearer ${this.authToken}`
-        },
-        body: {
-          data: encryptedData
-        }
-      })
-    );
-
-    return JSON.parse(Buffer.from(data, "base64").toString());
   }
 
   async signDigest(digest) {

--- a/src/client/ContentAccess.js
+++ b/src/client/ContentAccess.js
@@ -2718,7 +2718,7 @@ exports.LinkData = async function({libraryId, objectId, versionHash, writeToken,
 
 exports.CreateEncryptionConk = async function({libraryId, objectId, versionHash, writeToken, createKMSConk=true}) {
   if(this.signer.remoteSigner) {
-    await this.signer.PublicKey();
+    return;
   }
 
   ValidateParameters({libraryId, objectId, versionHash});
@@ -2743,9 +2743,7 @@ exports.CreateEncryptionConk = async function({libraryId, objectId, versionHash,
     });
 
   if(existingUserCap) {
-    this.encryptionConks[objectId] = this.signer.remoteSigner ?
-      await this.signer.DecryptCap(existingUserCap) :
-      await this.Crypto.DecryptCap(existingUserCap, this.signer._signingKey().privateKey);
+    this.encryptionConks[objectId] = await this.Crypto.DecryptCap(existingUserCap, this.signer._signingKey().privateKey);
   } else {
     this.encryptionConks[objectId] = await this.Crypto.GeneratePrimaryConk({
       spaceId: this.contentSpaceId,
@@ -2848,9 +2846,7 @@ exports.EncryptionConk = async function({libraryId, objectId, versionHash, write
       });
 
     if(existingUserCap) {
-      this.encryptionConks[objectId] = this.signer.remoteSigner ?
-        await this.signer.DecryptCap(existingUserCap) :
-        await this.Crypto.DecryptCap(existingUserCap, this.signer._signingKey().privateKey);
+      this.encryptionConks[objectId] = await this.Crypto.DecryptCap(existingUserCap, this.signer._signingKey().privateKey);
     } else if(writeToken) {
       await this.CreateEncryptionConk({libraryId, objectId, versionHash, writeToken, createKMSConk: false});
     } else {

--- a/src/client/ContentManagement.js
+++ b/src/client/ContentManagement.js
@@ -680,9 +680,7 @@ exports.CopyContentObject = async function({libraryId, originalVersionHash, opti
   const userCapKey = `eluv.caps.iusr${this.utils.AddressToHash(this.signer.address)}`;
 
   if(metadata[userCapKey]) {
-    const userConkKey = this.signer.remoteSigner ?
-      await this.signer.DecryptCap(metadata[userCapKey]) :
-      await this.Crypto.DecryptCap(metadata[userCapKey], this.signer._signingKey().privateKey);
+    const userConkKey = await this.Crypto.DecryptCap(metadata[userCapKey], this.signer._signingKey().privateKey);
     userConkKey.qid = objectId;
 
     await this.ReplaceMetadata({
@@ -735,9 +733,7 @@ exports.CreateNonOwnerCap = async function({objectId, libraryId, publicKey, writ
     throw Error("No user cap found for current user");
   }
 
-  const userConk = this.signer.remoteSigner ?
-    await this.signer.DecryptCap(userCapValue) :
-    await this.Crypto.DecryptCap(userCapValue, this.signer._signingKey().privateKey);
+  const userConk = await this.Crypto.DecryptCap(userCapValue, this.signer._signingKey().privateKey);
 
   const publicAddress = this.utils.PublicKeyToAddress(publicKey);
 


### PR DESCRIPTION
This reverts commit 26ca57a99dc3702bb502618aa498691a9d171339.

```
commit 26ca57a99dc3702bb502618aa498691a9d171339 (HEAD -> develop, origin/develop)
Date:   Wed Jul 15 13:14:10 2026 -0700

    remote-signer decrypt + pubkey (#363)
```

or, just run with that and clean it up with https://github.com/eluv-io/elv-client-js/pull/365