### PR TITLE
Stream create profile merge

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -25,8 +25,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '19'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - name: Configure git
         run: |

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/eluvio/elv-client-js.git"
+    "url": "git+https://github.com/eluv-io/elv-client-js.git"
   },
   "files": [
     "/build",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
   "browser": {
     "fs": false
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/eluvio/elv-client-js.git"
+  },
   "files": [
     "/build",
     "/dist",

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -322,15 +322,16 @@ exports.StreamCreate = async function({
         video_type: "live",
         slug: slugify(name)
       }
-    },
-    "live_recording_config": liveRecordingConfig
+    }
   };
 
-  const oldProfile = await this.ContentObjectMetadata({
+  const currentLiveRecordingConfig = await this.ContentObjectMetadata({
     libraryId,
     objectId,
-    metadataSubtree: "live_recording_config/name"
-  });
+    metadataSubtree: "live_recording_config"
+  }) || {};
+
+  const oldProfile = currentLiveRecordingConfig.name;
 
   if(liveRecordingConfig?.name && liveRecordingConfig.name !== oldProfile) {
     metadata.public.asset_metadata.profile_last_updated = new Date().toISOString();
@@ -341,6 +342,15 @@ exports.StreamCreate = async function({
     objectId,
     writeToken,
     metadata
+  });
+
+  // Full overwrite avoids the server-side merge mixing streams from the old and new profile
+  await this.ReplaceMetadata({
+    libraryId,
+    objectId,
+    writeToken,
+    metadataSubtree: "live_recording_config",
+    metadata: R.mergeDeepRight(currentLiveRecordingConfig, liveRecordingConfig)
   });
 
   try {


### PR DESCRIPTION
- Replace `live_recording_config` via ReplaceMetadata with a deep merge of the current
  and new config — avoids the server-side merge mixing streams from the old and new profile.                     
- CI: bump build-and-publish.yml Node.js setup from v19 to v24, add an npm install -g npm@latest step before   
  publishing.                                                                                                    
- Add missing repository field (git+https://github.com/eluvio/elv-client-js.git) to package.json. 