### PR TITLE
Handle deleted stream case for outputs list

### DIFF
--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -1090,9 +1090,9 @@ exports.StreamStatus = async function({name, showParams=false, writeToken}) {
         status.recordingStatus = lroStatus.custom.status;
       }
     } catch(error) {
-      console.log("LRO Status (failed): ", error.response.statusCode);
+      console.log("LRO Status (failed): ", error.response?.statusCode);
       status.state = "stopped";
-      status.error = error.response;
+      status.error = error.response || error.message;
       return status;
     }
 
@@ -3581,9 +3581,13 @@ exports.OutputsList = async function({libraryId, objectId, includeState=true}) {
 
   const nodeUrls = {};
   await this.utils.LimitedMap(10, nodeIds, async nodeId => {
-    const nodes = await this.SpaceNodes({matchNodeId: nodeId});
-    const fabricUrl = nodes?.[0]?.services?.fabric_api?.urls?.[0];
-    if(fabricUrl) { nodeUrls[nodeId] = fabricUrl; }
+    try {
+      const nodes = await this.SpaceNodes({matchNodeId: nodeId});
+      const fabricUrl = nodes?.[0]?.services?.fabric_api?.urls?.[0];
+      if(fabricUrl) { nodeUrls[nodeId] = fabricUrl; }
+    } catch(error) {
+      this.Log(`Failed to resolve node ${nodeId}: ${error.message}`, true);
+    }
   });
 
   // Rewrite fabric-generated srt_pull URLs to the egress host, and group outputs by node

--- a/src/client/LiveStream.js
+++ b/src/client/LiveStream.js
@@ -3532,6 +3532,13 @@ exports.OutputsList = async function({libraryId, objectId, includeState=true}) {
       method: "live/outputs",
       constant:  true
     });
+  } catch(error) {
+    if(error.status === 404) {
+      // Stream object may have been deleted
+      return {};
+    }
+
+    throw error;
   } finally {
     restore();
   }
@@ -3544,17 +3551,22 @@ exports.OutputsList = async function({libraryId, objectId, includeState=true}) {
       const streamId = value.input?.stream;
       if(!streamId) { return; }
 
-      const [streamLibraryId, streamStatus] = await Promise.all([
-        this.ContentObjectLibraryId({objectId: streamId}),
-        this.StreamStatus({name: streamId})
-      ]);
+      try {
+        const [streamLibraryId, streamStatus] = await Promise.all([
+          this.ContentObjectLibraryId({objectId: streamId}),
+          this.StreamStatus({name: streamId})
+        ]);
 
-      value.input.name = await this.ContentObjectMetadata({
-        libraryId: streamLibraryId,
-        objectId: streamId,
-        metadataSubtree: "/public/name",
-      });
-      value.input.status = streamStatus?.state;
+        value.input.name = await this.ContentObjectMetadata({
+          libraryId: streamLibraryId,
+          objectId: streamId,
+          metadataSubtree: "/public/name",
+        });
+        value.input.status = streamStatus?.state;
+      } catch(error) {
+        // Stream object may have been deleted
+        value.input.status = "unavailable";
+      }
     }
   );
 


### PR DESCRIPTION
Handle deleted streams in `OutputsList`
- Return {} when live/outputs returns a 404
- Catch per-output errors when an output's input stream was deleted, instead of failing the whole list